### PR TITLE
Harden workspace sandbox symlink handling

### DIFF
--- a/src/workspace/WorkspaceSandbox.ts
+++ b/src/workspace/WorkspaceSandbox.ts
@@ -28,6 +28,8 @@ export class WorkspaceSandbox {
     if (isDeniedPath(rel)) throw new Error(`Path is denied by sandbox: ${rel}`);
     const realAbs = fs.realpathSync(abs);
     if (!isInside(realAbs, this.root)) throw new Error(`Path escapes workspace: ${inputPath}`);
+    const realRel = this.relative(realAbs);
+    if (isDeniedPath(realRel)) throw new Error(`Path is denied by sandbox: ${realRel}`);
     const stat = fs.statSync(realAbs);
     if (!stat.isFile()) throw new Error(`Not a file: ${rel}`);
     if (looksBinary(realAbs)) throw new Error(`Binary file rejected: ${rel}`);

--- a/src/workspace/WorkspaceSandbox.ts
+++ b/src/workspace/WorkspaceSandbox.ts
@@ -26,16 +26,19 @@ export class WorkspaceSandbox {
     const abs = this.resolvePath(inputPath);
     const rel = this.relative(abs);
     if (isDeniedPath(rel)) throw new Error(`Path is denied by sandbox: ${rel}`);
-    const stat = fs.statSync(abs);
+    const realAbs = fs.realpathSync(abs);
+    if (!isInside(realAbs, this.root)) throw new Error(`Path escapes workspace: ${inputPath}`);
+    const stat = fs.statSync(realAbs);
     if (!stat.isFile()) throw new Error(`Not a file: ${rel}`);
-    if (looksBinary(abs)) throw new Error(`Binary file rejected: ${rel}`);
-    return abs;
+    if (looksBinary(realAbs)) throw new Error(`Binary file rejected: ${rel}`);
+    return realAbs;
   }
 
   assertWritablePatchPath(inputPath: string): string {
     const abs = this.resolvePath(inputPath);
     const rel = this.relative(abs);
     if (isDeniedPath(rel)) throw new Error(`Patch target denied by sandbox: ${rel}`);
+    assertNoSymlinkPathComponents(abs, this.root, inputPath);
     return abs;
   }
 }
@@ -62,4 +65,20 @@ export function looksBinary(absPath: string): boolean {
 function isInside(child: string, parent: string): boolean {
   const relative = path.relative(parent, child);
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function assertNoSymlinkPathComponents(absPath: string, root: string, inputPath: string): void {
+  const relative = path.relative(root, absPath);
+  if (relative === "" || relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`Path escapes workspace: ${inputPath}`);
+  }
+
+  let current = root;
+  for (const segment of relative.split(path.sep)) {
+    current = path.join(current, segment);
+    if (!fs.existsSync(current)) return;
+    if (fs.lstatSync(current).isSymbolicLink()) {
+      throw new Error(`Path contains symlink denied by sandbox: ${inputPath}`);
+    }
+  }
 }

--- a/tests/workspaceSandbox.test.mjs
+++ b/tests/workspaceSandbox.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { WorkspaceSandbox } from "../dist/workspace/WorkspaceSandbox.js";
+
+test("readable files must resolve inside the workspace", (t) => {
+  const { root, outside } = makeWorkspace();
+  const outsideFile = path.join(outside, "secret.txt");
+  fs.writeFileSync(outsideFile, "secret");
+
+  const linkPath = path.join(root, "secret-link.txt");
+  if (!trySymlink(outsideFile, linkPath, "file")) {
+    t.skip("file symlinks are not available in this environment");
+    return;
+  }
+
+  const sandbox = new WorkspaceSandbox(root);
+  assert.throws(() => sandbox.assertReadableFile("secret-link.txt"), /escapes workspace/);
+});
+
+test("writable patch paths reject symlink path components", (t) => {
+  const { root, outside } = makeWorkspace();
+  const linkPath = path.join(root, "linked-dir");
+  if (!trySymlink(outside, linkPath, "junction")) {
+    t.skip("directory symlinks are not available in this environment");
+    return;
+  }
+
+  const sandbox = new WorkspaceSandbox(root);
+  assert.throws(() => sandbox.assertWritablePatchPath("linked-dir/new-file.txt"), /symlink denied|escapes workspace/);
+});
+
+function makeWorkspace() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "grok-sandbox-"));
+  const root = path.join(base, "workspace");
+  const outside = path.join(base, "outside");
+  fs.mkdirSync(root);
+  fs.mkdirSync(outside);
+  return { root, outside };
+}
+
+function trySymlink(target, linkPath, type) {
+  try {
+    fs.symlinkSync(target, linkPath, type);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/workspaceSandbox.test.mjs
+++ b/tests/workspaceSandbox.test.mjs
@@ -20,6 +20,21 @@ test("readable files must resolve inside the workspace", (t) => {
   assert.throws(() => sandbox.assertReadableFile("secret-link.txt"), /escapes workspace/);
 });
 
+test("readable symlinks cannot bypass denied workspace paths", (t) => {
+  const { root } = makeWorkspace();
+  const envPath = path.join(root, ".env");
+  fs.writeFileSync(envPath, "SECRET=value");
+
+  const linkPath = path.join(root, "safe-link.txt");
+  if (!trySymlink(envPath, linkPath, "file")) {
+    t.skip("file symlinks are not available in this environment");
+    return;
+  }
+
+  const sandbox = new WorkspaceSandbox(root);
+  assert.throws(() => sandbox.assertReadableFile("safe-link.txt"), /Path is denied by sandbox: \.env/);
+});
+
 test("writable patch paths reject symlink path components", (t) => {
   const { root, outside } = makeWorkspace();
   const linkPath = path.join(root, "linked-dir");


### PR DESCRIPTION
## Summary
- Resolve readable file targets to real paths and reject targets that escape the workspace
- Reject symlink path components for writable patch paths
- Add workspace sandbox symlink coverage for read and write escape cases

Fixes #2.

## Tests
- `npm test`