### PR TITLE
Keep denied commands blocked in auto-all mode

### DIFF
--- a/src/approval/ApprovalPolicy.ts
+++ b/src/approval/ApprovalPolicy.ts
@@ -18,14 +18,14 @@ export class ApprovalPolicy {
   async approveCommand(command: string, reason: string, options: { background?: boolean } = {}): Promise<{ approved: boolean; risk: CommandRisk; message?: string }> {
     const risk = classifyCommand(command, options.background ?? false);
     const key = approvalKey(command, risk, options.background ?? false);
+    if (risk === "deny" || risk === "destructive") {
+      return { approved: false, risk, message: "Command is denied by safety policy." };
+    }
     if (this.rememberedApprovals.has(key)) {
       return { approved: true, risk };
     }
     if (this.currentMode === "auto-all") {
       return { approved: true, risk };
-    }
-    if (risk === "deny" || risk === "destructive") {
-      return { approved: false, risk, message: "Command is denied by safety policy." };
     }
     if (this.currentMode === "auto-local" && risk !== "global_environment_change") {
       return { approved: true, risk };

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -84,7 +84,8 @@ test("approval policy supports local and all automation levels", async () => {
   assert.equal((await autoLocal.approveCommand("npm install", "install local dependencies")).approved, true);
 
   const autoAll = new ApprovalPolicy("auto-all");
-  assert.equal((await autoAll.approveCommand("git push origin main", "push")).approved, true);
+  assert.equal((await autoAll.approveCommand("npm install", "install local dependencies")).approved, true);
+  assert.equal((await autoAll.approveCommand("git push origin main", "push")).approved, false);
 
   const never = new ApprovalPolicy("never");
   assert.equal(await never.approvePatch("workspace patch"), false);


### PR DESCRIPTION
## Summary
- Check `deny` and `destructive` command risks before remembered approvals or `auto-all`
- Preserve `auto-all` approval for non-denied commands
- Update approval policy coverage for denied `git push` behavior

Fixes #4.

## Tests
- `npm test`