### PR TITLE
Persist task summary for resumed sessions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,6 +77,7 @@ async function runOne(task: string, opts: CliOpts, _kind: string): Promise<void>
   await agent.background.stopAll("one-shot exit cleanup");
   const store = new SessionStore(process.cwd());
   const session = store.create(agent.config.model, opts.approval ?? "on-request");
+  session.taskSummary = task;
   session.contextItems = agent.context.list();
   session.backgroundProcesses = agent.background.list();
   store.save(session);


### PR DESCRIPTION
## Summary
- Save the original one-shot task into `session.taskSummary`
- Let later `resume` calls preserve the task context already used by the session model

Fixes #8.

## Tests
- `npm test`