### PR TITLE
Validate max steps before agent startup

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -54,7 +54,7 @@ async function makeAgent(opts: CliOpts, task = ""): Promise<Agent> {
     model: opts.model,
     approval: opts.approval,
     toolChoice: opts.toolChoice,
-    maxSteps: opts.maxSteps ? Number(opts.maxSteps) : undefined,
+    maxSteps: parseMaxSteps(opts.maxSteps),
     serverTools: opts.serverTools,
     enableWebSearch: opts.enableWebSearch,
     enableXSearch: opts.enableXSearch
@@ -68,6 +68,16 @@ async function makeAgent(opts: CliOpts, task = ""): Promise<Agent> {
     process.exit(130);
   });
   return agent;
+}
+
+export function parseMaxSteps(value?: string): number | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  const parsed = Number(normalized);
+  if (!/^\d+$/.test(normalized) || !Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error("--max-steps must be a positive integer");
+  }
+  return parsed;
 }
 
 async function runOne(task: string, opts: CliOpts, _kind: string): Promise<void> {

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -11,6 +11,7 @@ import { ApprovalPolicy } from "../dist/approval/ApprovalPolicy.js";
 import { CORE_SYSTEM_PROMPT } from "../dist/agent/prompts.js";
 import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
+import { parseMaxSteps } from "../dist/cli.js";
 
 const root = process.cwd();
 const skillPath = path.join(root, "src", "skills", "builtin", "tree-based-code-navigation.md");
@@ -136,4 +137,14 @@ test("undefined CLI overrides do not disable default server-side search tools", 
   assert.equal(config.serverTools, true);
   assert.equal(config.enableWebSearch, true);
   assert.equal(config.enableXSearch, true);
+});
+
+test("CLI max steps parser accepts only positive integers", () => {
+  assert.equal(parseMaxSteps(undefined), undefined);
+  assert.equal(parseMaxSteps("1"), 1);
+  assert.equal(parseMaxSteps("30"), 30);
+  assert.throws(() => parseMaxSteps("0"), /--max-steps must be a positive integer/);
+  assert.throws(() => parseMaxSteps("-1"), /--max-steps must be a positive integer/);
+  assert.throws(() => parseMaxSteps("1.5"), /--max-steps must be a positive integer/);
+  assert.throws(() => parseMaxSteps("abc"), /--max-steps must be a positive integer/);
 });


### PR DESCRIPTION
## Summary
- Parse `--max-steps` through a dedicated positive-integer validator
- Fail fast before agent construction for zero, negative, decimal, or non-numeric values
- Add parser coverage for valid and invalid max-step inputs

Fixes #7.

## Tests
- `npm test`