### PR TITLE
Clarify server-side search disable flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Global flags:
 --tool-choice <auto|required|none>
 --max-steps <number>
 --no-server-tools
---enable-web-search
---enable-x-search
+--no-web-search
+--no-x-search
 ```
 
 ## Interactive Mode
@@ -126,8 +126,8 @@ xAI server-side built-ins are enabled by default:
 
 - `web_search` is included by default
 - `x_search` is included by default
-- `--enable-web-search` explicitly enables `{ type: "web_search" }`
-- `--enable-x-search` explicitly enables `{ type: "x_search" }`
+- `--no-web-search` disables `{ type: "web_search" }`
+- `--no-x-search` disables `{ type: "x_search" }`
 - `--no-server-tools` disables server-side tools
 
 Server-side tools are executed by xAI. Local filesystem, shell, git, patching, and background process tools are always custom local tools executed by this CLI.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,8 +14,8 @@ type CliOpts = {
   toolChoice?: ToolChoice;
   maxSteps?: string;
   serverTools?: boolean;
-  enableWebSearch?: boolean;
-  enableXSearch?: boolean;
+  webSearch?: boolean;
+  xSearch?: boolean;
 };
 
 export async function main(): Promise<void> {
@@ -29,8 +29,8 @@ export async function main(): Promise<void> {
     .option("--tool-choice <choice>", "auto|required|none", "auto")
     .option("--max-steps <number>", "Maximum agent steps", "30")
     .option("--no-server-tools", "Disable xAI server-side tools")
-    .option("--enable-web-search", "Enable xAI web_search server-side tool")
-    .option("--enable-x-search", "Enable xAI x_search server-side tool");
+    .option("--no-web-search", "Disable xAI web_search server-side tool")
+    .option("--no-x-search", "Disable xAI x_search server-side tool");
 
   program.command("ask <question...>").description("Ask a question").action(async (question: string[], opts: CliOpts) => runOne(question.join(" "), opts, "ask"));
   program.command("edit <task...>").description("Run an edit task").action(async (task: string[], opts: CliOpts) => runOne(task.join(" "), opts, "edit"));
@@ -50,14 +50,15 @@ export async function main(): Promise<void> {
 }
 
 async function makeAgent(opts: CliOpts, task = ""): Promise<Agent> {
+  const toolOverrides = parseServerToolOverrides(process.argv.slice(2));
   const config = loadConfig(process.cwd(), {
     model: opts.model,
     approval: opts.approval,
     toolChoice: opts.toolChoice,
     maxSteps: opts.maxSteps ? Number(opts.maxSteps) : undefined,
-    serverTools: opts.serverTools,
-    enableWebSearch: opts.enableWebSearch,
-    enableXSearch: opts.enableXSearch
+    serverTools: toolOverrides.serverTools,
+    enableWebSearch: toolOverrides.enableWebSearch,
+    enableXSearch: toolOverrides.enableXSearch
   });
   const client = createXaiClient();
   const agent = new Agent(client, config, task);
@@ -68,6 +69,14 @@ async function makeAgent(opts: CliOpts, task = ""): Promise<Agent> {
     process.exit(130);
   });
   return agent;
+}
+
+export function parseServerToolOverrides(argv: string[]): { serverTools?: boolean; enableWebSearch?: boolean; enableXSearch?: boolean } {
+  return {
+    serverTools: argv.includes("--no-server-tools") ? false : undefined,
+    enableWebSearch: argv.includes("--no-web-search") ? false : undefined,
+    enableXSearch: argv.includes("--no-x-search") ? false : undefined
+  };
 }
 
 async function runOne(task: string, opts: CliOpts, _kind: string): Promise<void> {

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -11,6 +11,7 @@ import { ApprovalPolicy } from "../dist/approval/ApprovalPolicy.js";
 import { CORE_SYSTEM_PROMPT } from "../dist/agent/prompts.js";
 import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
+import { parseServerToolOverrides } from "../dist/cli.js";
 
 const root = process.cwd();
 const skillPath = path.join(root, "src", "skills", "builtin", "tree-based-code-navigation.md");
@@ -136,4 +137,22 @@ test("undefined CLI overrides do not disable default server-side search tools", 
   assert.equal(config.serverTools, true);
   assert.equal(config.enableWebSearch, true);
   assert.equal(config.enableXSearch, true);
+});
+
+test("negative server-side search flags map to explicit config overrides", () => {
+  assert.deepEqual(parseServerToolOverrides([]), {
+    serverTools: undefined,
+    enableWebSearch: undefined,
+    enableXSearch: undefined
+  });
+  assert.deepEqual(parseServerToolOverrides(["--no-web-search"]), {
+    serverTools: undefined,
+    enableWebSearch: false,
+    enableXSearch: undefined
+  });
+  assert.deepEqual(parseServerToolOverrides(["--no-server-tools", "--no-x-search"]), {
+    serverTools: false,
+    enableWebSearch: undefined,
+    enableXSearch: false
+  });
 });


### PR DESCRIPTION
## Summary
- Replace positive search flags with `--no-web-search` and `--no-x-search`
- Apply server/search overrides only when the negative flags are explicitly present
- Update README flag documentation and add override parser coverage

Fixes #6.

## Tests
- `npm test`