### PR TITLE
Serialize side-effecting local tool calls

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -86,34 +86,7 @@ export class AgentLoop {
       }
       console.log(formatToolBatch(step, parsed.functionCalls.map((call) => call.name)));
 
-      const outputs = await Promise.all(parsed.functionCalls.map(async (call) => {
-        throwIfAborted(signal);
-        usedToolNames.add(call.name);
-        let args: unknown;
-        try {
-          args = JSON.parse(call.arguments || "{}");
-        } catch (error) {
-          args = {};
-          const result = { ok: false, error: { code: "json_parse_error", message: error instanceof Error ? error.message : String(error) } };
-          return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
-        }
-        const result = await this.tools.execute(call.name, args, this.toolCtx);
-        throwIfAborted(signal);
-        if (call.name === "apply_patch" && result.ok) hasModifiedFiles.value = true;
-        toolActionSummaries.push({
-          step,
-          name: call.name,
-          ok: result.ok,
-          summary: summarizeToolResult(result)
-        });
-        this.context.add({
-          type: "shell_output",
-          content: `tool ${call.name}(${call.arguments}) => ${JSON.stringify(result).slice(0, 4000)}`,
-          priority: 45,
-          expiresAfterSteps: 2
-        });
-        return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
-      }));
+      const outputs = await this.executeToolBatch(parsed.functionCalls, step, usedToolNames, toolActionSummaries, hasModifiedFiles, signal);
       pendingInput = outputs;
       step += 1;
     }
@@ -129,6 +102,67 @@ export class AgentLoop {
     const actionSection = toolActionSummaries.length > 0 ? `\n\n[Actions completed]\n${formatActionSummary(toolActionSummaries)}` : "";
     const suffix = `${actionSection}${diffSection}\n\n[Final checks]\nBackground: ${gate.backgroundStatus}\nDiff checked: ${gate.diffChecked ? "yes" : "not needed"}`;
     return finalText ? `${finalText}${suffix}` : `Stopped after max steps without a final model message.${suffix}`;
+  }
+
+  private async executeToolBatch(
+    functionCalls: Array<{ name: string; arguments?: string; call_id: string }>,
+    step: number,
+    usedToolNames: Set<string>,
+    toolActionSummaries: ToolActionSummary[],
+    hasModifiedFiles: { value: boolean },
+    signal?: AbortSignal
+  ): Promise<Array<{ type: "function_call_output"; call_id: string; output: string }>> {
+    const outputs: Array<{ type: "function_call_output"; call_id: string; output: string }> = [];
+    for (let index = 0; index < functionCalls.length;) {
+      const call = functionCalls[index];
+      if (this.tools.isReadOnly(call.name)) {
+        const readOnlyCalls = [];
+        while (index < functionCalls.length && this.tools.isReadOnly(functionCalls[index].name)) {
+          readOnlyCalls.push(functionCalls[index]);
+          index += 1;
+        }
+        outputs.push(...await Promise.all(readOnlyCalls.map((item) => this.executeOneToolCall(item, step, usedToolNames, toolActionSummaries, hasModifiedFiles, signal))));
+        continue;
+      }
+      outputs.push(await this.executeOneToolCall(call, step, usedToolNames, toolActionSummaries, hasModifiedFiles, signal));
+      index += 1;
+    }
+    return outputs;
+  }
+
+  private async executeOneToolCall(
+    call: { name: string; arguments?: string; call_id: string },
+    step: number,
+    usedToolNames: Set<string>,
+    toolActionSummaries: ToolActionSummary[],
+    hasModifiedFiles: { value: boolean },
+    signal?: AbortSignal
+  ): Promise<{ type: "function_call_output"; call_id: string; output: string }> {
+    throwIfAborted(signal);
+    usedToolNames.add(call.name);
+    let args: unknown;
+    try {
+      args = JSON.parse(call.arguments || "{}");
+    } catch (error) {
+      const result = { ok: false, error: { code: "json_parse_error", message: error instanceof Error ? error.message : String(error) } };
+      return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
+    }
+    const result = await this.tools.execute(call.name, args, this.toolCtx);
+    throwIfAborted(signal);
+    if (call.name === "apply_patch" && result.ok) hasModifiedFiles.value = true;
+    toolActionSummaries.push({
+      step,
+      name: call.name,
+      ok: result.ok,
+      summary: summarizeToolResult(result)
+    });
+    this.context.add({
+      type: "shell_output",
+      content: `tool ${call.name}(${call.arguments}) => ${JSON.stringify(result).slice(0, 4000)}`,
+      priority: 45,
+      expiresAfterSteps: 2
+    });
+    return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
   }
 }
 

--- a/src/tools/AgentTool.ts
+++ b/src/tools/AgentTool.ts
@@ -29,6 +29,7 @@ export type AgentTool = {
   execute: ToolExecutor;
   skill: ToolSkill;
   locality: "local" | "server";
+  readOnly: boolean;
 };
 
 export type ToolResult =

--- a/src/tools/ToolRegistry.ts
+++ b/src/tools/ToolRegistry.ts
@@ -19,6 +19,10 @@ export class ToolRegistry {
     return this.tools.has(name);
   }
 
+  isReadOnly(name: string): boolean {
+    return this.tools.get(name)?.readOnly ?? false;
+  }
+
   async execute(name: string, args: unknown, ctx: ToolExecutionContext): Promise<ToolResult> {
     const tool = this.tools.get(name);
     if (!tool) {

--- a/src/tools/definitions/helpers.ts
+++ b/src/tools/definitions/helpers.ts
@@ -20,7 +20,8 @@ export function makeTool<T extends ZodTypeAny>(
     schema: { type: "function", name, description, parameters },
     execute: async (args, ctx) => execute(validator.parse(args), ctx),
     skill: skillRegistry.get(name),
-    locality: "local"
+    locality: "local",
+    readOnly: false
   };
 }
 

--- a/src/tools/definitions/index.ts
+++ b/src/tools/definitions/index.ts
@@ -46,6 +46,24 @@ export const LOCAL_TOOL_NAMES = [
   "stop_all_background_commands"
 ];
 
+const READ_ONLY_LOCAL_TOOL_NAMES = new Set([
+  "inspect_environment",
+  "check_project_tooling",
+  "list_files",
+  "get_file_overview",
+  "read_file_range",
+  "search_text",
+  "search_symbols",
+  "search_code",
+  "find_symbol",
+  "get_related_files",
+  "expand_node",
+  "git_status",
+  "git_diff",
+  "list_background_commands",
+  "read_background_output"
+]);
+
 export function createLocalToolRegistry(skills: ToolSkillRegistry): ToolRegistry {
   const registry = new ToolRegistry();
   for (const tool of [
@@ -71,6 +89,7 @@ export function createLocalToolRegistry(skills: ToolSkillRegistry): ToolRegistry
     stopBackgroundCommandTool(skills),
     stopAllBackgroundCommandsTool(skills)
   ]) {
+    tool.readOnly = READ_ONLY_LOCAL_TOOL_NAMES.has(tool.name);
     registry.register(tool);
   }
   return registry;

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -68,6 +68,10 @@ test("tree search tools are registered and indexed", () => {
   assert.ok(names.includes("find_symbol"));
   assert.ok(names.includes("expand_node"));
   assert.ok(names.includes("get_related_files"));
+  assert.equal(tools.isReadOnly("search_code"), true);
+  assert.equal(tools.isReadOnly("git_diff"), true);
+  assert.equal(tools.isReadOnly("apply_patch"), false);
+  assert.equal(tools.isReadOnly("run_shell"), false);
   const index = toolSkills.toolIndex();
   assert.match(index, /search_code/);
   assert.match(index, /find_symbol/);


### PR DESCRIPTION
## Summary
- Add `readOnly` metadata to local tools and the tool registry
- Execute consecutive read-only tool calls in parallel while preserving response order
- Execute side-effecting or unknown local tools sequentially in model-provided order
- Add coverage for read-only metadata on local tools

Fixes #5.

## Tests
- `npm test`