### PR TITLE
Classify apply_patch approval risk

### DIFF
--- a/src/approval/ApprovalPolicy.ts
+++ b/src/approval/ApprovalPolicy.ts
@@ -2,6 +2,17 @@ import type { ApprovalMode } from "../config/loadConfig.js";
 import { classifyCommand, type CommandRisk } from "./RiskClassifier.js";
 import { promptApproval } from "./promptApproval.js";
 
+export type PatchApprovalMetadata = {
+  files: Array<{
+    path: string;
+    operation: "create" | "modify" | "delete";
+    additions: number;
+    deletions: number;
+  }>;
+};
+
+type PatchRisk = "safe" | "ask";
+
 export class ApprovalPolicy {
   private rememberedApprovals = new Set<string>();
 
@@ -50,10 +61,42 @@ export class ApprovalPolicy {
     };
   }
 
-  async approvePatch(reason: string): Promise<boolean> {
+  async approvePatch(reason: string, metadata?: PatchApprovalMetadata): Promise<boolean> {
     if (this.currentMode === "never") return false;
-    return true;
+    const risk = metadata ? classifyPatchRisk(metadata) : "safe";
+    if (risk === "safe") return true;
+    if (this.currentMode === "auto-safe") return false;
+    if (this.currentMode === "auto-local" || this.currentMode === "auto-all") return true;
+    const decision = await promptApproval(formatPatchApprovalCommand(metadata!), reason, "ask");
+    return decision.approved;
   }
+}
+
+export function classifyPatchRisk(metadata: PatchApprovalMetadata): PatchRisk {
+  for (const file of metadata.files) {
+    if (file.operation === "delete") return "ask";
+    if (file.deletions > 100) return "ask";
+    if (isHighRiskPatchPath(file.path)) return "ask";
+  }
+  return "safe";
+}
+
+function isHighRiskPatchPath(filePath: string): boolean {
+  const normalized = filePath.replace(/\\/g, "/").toLowerCase();
+  if (normalized === "package.json" || normalized.endsWith("/package.json")) return true;
+  if (/package-lock\.json$|pnpm-lock\.yaml$|yarn\.lock$|bun\.lockb?$/.test(normalized)) return true;
+  if (normalized.startsWith(".github/workflows/") || normalized === ".gitlab-ci.yml") return true;
+  if (/(^|\/)(dockerfile|compose\.ya?ml)$/.test(normalized)) return true;
+  if (/\.(sh|bash|zsh|fish|ps1|bat|cmd)$/.test(normalized)) return true;
+  if (/(^|\/)\.env(\.|$)/.test(normalized)) return true;
+  return false;
+}
+
+function formatPatchApprovalCommand(metadata: PatchApprovalMetadata): string {
+  const files = metadata.files
+    .map((file) => `${file.operation} ${file.path} (+${file.additions}/-${file.deletions})`)
+    .join(", ");
+  return `apply_patch ${files}`;
 }
 
 function approvalKey(command: string, risk: CommandRisk, background: boolean): string {

--- a/src/tools/definitions/applyPatch.ts
+++ b/src/tools/definitions/applyPatch.ts
@@ -6,6 +6,7 @@ import chalk from "chalk";
 import { schemas } from "../toolSchemas.js";
 import { makeTool } from "./helpers.js";
 import type { ToolSkillRegistry } from "../../tool-skills/ToolSkillRegistry.js";
+import type { PatchApprovalMetadata } from "../../approval/ApprovalPolicy.js";
 
 export function applyPatchTool(skills: ToolSkillRegistry) {
   return makeTool(
@@ -17,7 +18,8 @@ export function applyPatchTool(skills: ToolSkillRegistry) {
     async (args, ctx) => {
       const parsed = parsePatch(args.patch);
       if (parsed.length === 0) throw new Error("Patch is not a valid unified diff.");
-      const approved = await ctx.approval.approvePatch(args.reason);
+      const metadata = patchApprovalMetadata(parsed);
+      const approved = await ctx.approval.approvePatch(args.reason, metadata);
       if (!approved) throw new Error("Patch denied by approval policy.");
       const modified: string[] = [];
       for (const filePatch of parsed) {
@@ -52,4 +54,20 @@ function colorUnifiedDiff(patch: string): string {
 function cleanPatchPath(fileName?: string): string | undefined {
   if (!fileName) return undefined;
   return fileName.replace(/^a\//, "").replace(/^b\//, "");
+}
+
+function patchApprovalMetadata(parsed: ReturnType<typeof parsePatch>): PatchApprovalMetadata {
+  return {
+    files: parsed.map((filePatch) => {
+      const target = cleanPatchPath(filePatch.newFileName && filePatch.newFileName !== "/dev/null" ? filePatch.newFileName : filePatch.oldFileName) ?? "unknown";
+      const additions = filePatch.hunks.reduce((sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("+") && !line.startsWith("+++")).length, 0);
+      const deletions = filePatch.hunks.reduce((sum, hunk) => sum + hunk.lines.filter((line) => line.startsWith("-") && !line.startsWith("---")).length, 0);
+      return {
+        path: target,
+        operation: filePatch.oldFileName === "/dev/null" ? "create" : filePatch.newFileName === "/dev/null" ? "delete" : "modify",
+        additions,
+        deletions
+      };
+    })
+  };
 }

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -7,7 +7,7 @@ import { ContextManager } from "../dist/context/ContextManager.js";
 import { buildModelInput } from "../dist/agent/modelInputBuilder.js";
 import { ToolSkillRegistry } from "../dist/tool-skills/ToolSkillRegistry.js";
 import { LOCAL_TOOL_NAMES, createLocalToolRegistry } from "../dist/tools/definitions/index.js";
-import { ApprovalPolicy } from "../dist/approval/ApprovalPolicy.js";
+import { ApprovalPolicy, classifyPatchRisk } from "../dist/approval/ApprovalPolicy.js";
 import { CORE_SYSTEM_PROMPT } from "../dist/agent/prompts.js";
 import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
@@ -89,6 +89,25 @@ test("approval policy supports local and all automation levels", async () => {
 
   const never = new ApprovalPolicy("never");
   assert.equal(await never.approvePatch("workspace patch"), false);
+});
+
+test("patch approval classifies higher-risk patch metadata", async () => {
+  const safePatch = { files: [{ path: "src/example.ts", operation: "modify", additions: 3, deletions: 1 }] };
+  const packagePatch = { files: [{ path: "package.json", operation: "modify", additions: 1, deletions: 1 }] };
+  const deletePatch = { files: [{ path: "src/old.ts", operation: "delete", additions: 0, deletions: 20 }] };
+  const largeDeletionPatch = { files: [{ path: "src/big.ts", operation: "modify", additions: 0, deletions: 101 }] };
+
+  assert.equal(classifyPatchRisk(safePatch), "safe");
+  assert.equal(classifyPatchRisk(packagePatch), "ask");
+  assert.equal(classifyPatchRisk(deletePatch), "ask");
+  assert.equal(classifyPatchRisk(largeDeletionPatch), "ask");
+
+  const autoSafe = new ApprovalPolicy("auto-safe");
+  assert.equal(await autoSafe.approvePatch("safe patch", safePatch), true);
+  assert.equal(await autoSafe.approvePatch("package patch", packagePatch), false);
+
+  const autoLocal = new ApprovalPolicy("auto-local");
+  assert.equal(await autoLocal.approvePatch("package patch", packagePatch), true);
 });
 
 test("system prompt requires plans and final action summaries", () => {


### PR DESCRIPTION
## Summary
- Pass parsed patch metadata into `ApprovalPolicy.approvePatch()`
- Classify deletes, large deletions, package files, CI config, scripts, Docker/compose files, and env-like paths as higher-risk patches
- Keep safe patches auto-approved while making `auto-safe` reject higher-risk patches and `on-request` prompt for approval
- Add approval policy coverage for safe and higher-risk patch metadata

Fixes #3.

## Tests
- `npm test`