### PR TITLE
Fix apply_patch create and delete file operations

### DIFF
--- a/src/tools/definitions/applyPatch.ts
+++ b/src/tools/definitions/applyPatch.ts
@@ -22,6 +22,7 @@ export function applyPatchTool(skills: ToolSkillRegistry) {
       const approved = await ctx.approval.approvePatch(args.reason, metadata);
       if (!approved) throw new Error("Patch denied by approval policy.");
       const modified: string[] = [];
+      const deleted: string[] = [];
       for (const filePatch of parsed) {
         const target = cleanPatchPath(filePatch.newFileName && filePatch.newFileName !== "/dev/null" ? filePatch.newFileName : filePatch.oldFileName);
         if (!target) throw new Error("Patch file path missing.");
@@ -29,6 +30,11 @@ export function applyPatchTool(skills: ToolSkillRegistry) {
         const oldContent = filePatch.oldFileName === "/dev/null" ? "" : await fs.readFile(abs, "utf8").catch(() => "");
         const next = applyOnePatch(oldContent, filePatch);
         if (next === false) throw new Error(`Patch failed for ${target}`);
+        if (filePatch.newFileName === "/dev/null") {
+          await fs.unlink(abs);
+          deleted.push(target);
+          continue;
+        }
         await fs.mkdir(path.dirname(abs), { recursive: true }).catch(() => undefined);
         await fs.writeFile(abs, next, "utf8");
         modified.push(target);
@@ -36,7 +42,7 @@ export function applyPatchTool(skills: ToolSkillRegistry) {
       console.log(chalk.green("Applied patch:"));
       console.log(colorUnifiedDiff(args.patch));
       ctx.context.add({ type: "patch", content: args.patch, priority: 85, source: { command: args.reason } });
-      return { modifiedFiles: modified, reminder: "Run git_diff and the smallest relevant tests/checks before final answer." };
+      return { modifiedFiles: modified, deletedFiles: deleted, reminder: "Run git_diff and the smallest relevant tests/checks before final answer." };
     }
   );
 }

--- a/src/workspace/WorkspaceSandbox.ts
+++ b/src/workspace/WorkspaceSandbox.ts
@@ -37,11 +37,19 @@ export class WorkspaceSandbox {
   }
 
   assertWritablePatchPath(inputPath: string): string {
-    const abs = this.resolvePath(inputPath);
+    const abs = this.resolveWritablePath(inputPath);
     const rel = this.relative(abs);
     if (isDeniedPath(rel)) throw new Error(`Patch target denied by sandbox: ${rel}`);
     assertNoSymlinkPathComponents(abs, this.root, inputPath);
     return abs;
+  }
+
+  private resolveWritablePath(inputPath: string): string {
+    if (inputPath.includes("\0")) throw new Error("Invalid path.");
+    const resolved = path.resolve(this.root, inputPath);
+    const realParent = fs.realpathSync(nearestExistingAncestor(resolved));
+    if (!isInside(realParent, this.root)) throw new Error(`Path escapes workspace: ${inputPath}`);
+    return resolved;
   }
 }
 
@@ -83,4 +91,14 @@ function assertNoSymlinkPathComponents(absPath: string, root: string, inputPath:
       throw new Error(`Path contains symlink denied by sandbox: ${inputPath}`);
     }
   }
+}
+
+function nearestExistingAncestor(absPath: string): string {
+  let current = fs.existsSync(absPath) ? absPath : path.dirname(absPath);
+  while (!fs.existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) throw new Error(`No existing path ancestor: ${absPath}`);
+    current = parent;
+  }
+  return current;
 }

--- a/tests/applyPatch.test.mjs
+++ b/tests/applyPatch.test.mjs
@@ -1,0 +1,59 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { applyPatchTool } from "../dist/tools/definitions/applyPatch.js";
+import { ApprovalPolicy } from "../dist/approval/ApprovalPolicy.js";
+import { ContextManager } from "../dist/context/ContextManager.js";
+import { WorkspaceSandbox } from "../dist/workspace/WorkspaceSandbox.js";
+import { ToolSkillRegistry } from "../dist/tool-skills/ToolSkillRegistry.js";
+
+test("apply_patch creates files inside new directories", async () => {
+  const root = makeWorkspace();
+  const tool = applyPatchTool(new ToolSkillRegistry(root));
+  const patch = [
+    "--- /dev/null",
+    "+++ b/new-dir/file.txt",
+    "@@ -0,0 +1 @@",
+    "+hello",
+    ""
+  ].join("\n");
+
+  const result = await tool.execute({ patch, reason: "create nested file" }, makeContext(root));
+  assert.deepEqual(result.modifiedFiles, ["new-dir/file.txt"]);
+  assert.equal(fs.readFileSync(path.join(root, "new-dir", "file.txt"), "utf8"), "hello\n");
+});
+
+test("apply_patch removes files for delete patches", async () => {
+  const root = makeWorkspace();
+  const target = path.join(root, "delete-me.txt");
+  fs.writeFileSync(target, "hello\n");
+  const tool = applyPatchTool(new ToolSkillRegistry(root));
+  const patch = [
+    "--- a/delete-me.txt",
+    "+++ /dev/null",
+    "@@ -1 +0,0 @@",
+    "-hello",
+    ""
+  ].join("\n");
+
+  const result = await tool.execute({ patch, reason: "delete file" }, makeContext(root));
+  assert.deepEqual(result.modifiedFiles, []);
+  assert.deepEqual(result.deletedFiles, ["delete-me.txt"]);
+  assert.equal(fs.existsSync(target), false);
+});
+
+function makeWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "grok-apply-patch-"));
+}
+
+function makeContext(root) {
+  return {
+    workspaceRoot: root,
+    sandbox: new WorkspaceSandbox(root),
+    approval: new ApprovalPolicy("auto-local"),
+    background: {},
+    context: new ContextManager()
+  };
+}

--- a/tests/workspaceSandbox.test.mjs
+++ b/tests/workspaceSandbox.test.mjs
@@ -47,6 +47,13 @@ test("writable patch paths reject symlink path components", (t) => {
   assert.throws(() => sandbox.assertWritablePatchPath("linked-dir/new-file.txt"), /symlink denied|escapes workspace/);
 });
 
+test("writable patch paths allow new directories inside the workspace", () => {
+  const { root } = makeWorkspace();
+  const sandbox = new WorkspaceSandbox(root);
+  const abs = sandbox.assertWritablePatchPath("new-dir/nested/file.ts");
+  assert.equal(abs, path.join(root, "new-dir", "nested", "file.ts"));
+});
+
 function makeWorkspace() {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "grok-sandbox-"));
   const root = path.join(base, "workspace");


### PR DESCRIPTION
## Summary
- Allow writable patch targets whose new directory chain does not exist yet, as long as the nearest existing ancestor stays inside the workspace
- Remove files for delete patches instead of writing empty content
- Return `deletedFiles` separately from `modifiedFiles`
- Add apply_patch coverage for creating files in new directories and deleting files

Fixes #19.
Fixes #20.

## Tests
- `npm test`