### PR TITLE
Deny nested env files in workspace sandbox

### DIFF
--- a/src/workspace/WorkspaceSandbox.ts
+++ b/src/workspace/WorkspaceSandbox.ts
@@ -55,11 +55,14 @@ export class WorkspaceSandbox {
 
 export function isDeniedPath(relPath: string): boolean {
   const normalized = relPath.replace(/\\/g, "/");
-  if (normalized === ".env.example" || normalized.endsWith("/.env.example")) return false;
-  if (normalized === ".env" || normalized.startsWith(".env.")) return true;
-  if (normalized.includes("/.env.")) return true;
+  if (normalized.split("/").some((segment) => isDeniedEnvSegment(segment))) return true;
   if (/\.(min\.js|min\.css)$/.test(normalized)) return true;
   return DEFAULT_IGNORES.filter((pattern) => !pattern.includes("*")).some((pattern) => normalized === pattern || normalized.startsWith(`${pattern}/`));
+}
+
+function isDeniedEnvSegment(segment: string): boolean {
+  if (segment === ".env.example") return false;
+  return segment === ".env" || segment.startsWith(".env.");
 }
 
 export function looksBinary(absPath: string): boolean {

--- a/tests/workspaceSandbox.test.mjs
+++ b/tests/workspaceSandbox.test.mjs
@@ -37,15 +37,24 @@ test("readable symlinks cannot bypass denied workspace paths", (t) => {
 
 test(".env.example is readable while real env files stay denied", () => {
   const { root } = makeWorkspace();
+  fs.mkdirSync(path.join(root, "sub"));
   fs.writeFileSync(path.join(root, ".env"), "SECRET=value");
   fs.writeFileSync(path.join(root, ".env.local"), "SECRET=value");
   fs.writeFileSync(path.join(root, ".env.example"), "XAI_API_KEY=");
+  fs.writeFileSync(path.join(root, "sub", ".env"), "SECRET=value");
+  fs.writeFileSync(path.join(root, "sub", ".env.local"), "SECRET=value");
+  fs.writeFileSync(path.join(root, "sub", ".env.example"), "XAI_API_KEY=");
 
   const sandbox = new WorkspaceSandbox(root);
   assert.equal(isDeniedPath(".env.example"), false);
+  assert.equal(isDeniedPath("sub/.env.example"), false);
+  assert.equal(isDeniedPath("sub/.env"), true);
   assert.equal(path.basename(sandbox.assertReadableFile(".env.example")), ".env.example");
+  assert.equal(path.basename(sandbox.assertReadableFile("sub/.env.example")), ".env.example");
   assert.throws(() => sandbox.assertReadableFile(".env"), /Path is denied by sandbox: \.env/);
   assert.throws(() => sandbox.assertReadableFile(".env.local"), /Path is denied by sandbox: \.env\.local/);
+  assert.throws(() => sandbox.assertReadableFile("sub/.env"), /Path is denied by sandbox: sub\/\.env/);
+  assert.throws(() => sandbox.assertReadableFile("sub/.env.local"), /Path is denied by sandbox: sub\/\.env\.local/);
 });
 
 test("writable patch paths reject symlink path components", (t) => {


### PR DESCRIPTION
## Summary
- Treat `.env` and `.env.*` as denied path segments at any directory depth
- Preserve the `.env.example` allowlist at root and nested paths
- Add regression coverage for nested `.env`, `.env.local`, and `.env.example`

Fixes #25.

## Tests
- `npm test`