### PR TITLE
Separate session and Git status commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ grok-code edit "modify task"
 grok-code review
 grok-code learn-project
 grok-code status
+grok-code git-status
 grok-code diff
 grok-code resume
 grok-code resume <session-id>
@@ -81,6 +82,7 @@ Useful slash commands:
 ```txt
 /help
 /status
+/git-status
 /diff
 /approval <mode>
 /learn-project
@@ -270,6 +272,18 @@ Show a git-style diff in interactive mode:
 
 ```txt
 /diff
+```
+
+Show the current session/runtime status:
+
+```txt
+/status
+```
+
+Show repository status:
+
+```txt
+/git-status
 ```
 
 Start and stop a dev server:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { createXaiClient } from "./api/xaiClient.js";
 import { Agent } from "./agent/Agent.js";
 import { loadConfig, type ApprovalMode, type ToolChoice } from "./config/loadConfig.js";
 import { startRepl } from "./ui/repl.js";
-import { printHeader } from "./ui/terminal.js";
+import { formatSessionStatus, printHeader } from "./ui/terminal.js";
 import { SessionStore } from "./session/SessionStore.js";
 import { colorDiff } from "./ui/diffView.js";
 import { PROJECT_UNDERSTANDING_TASK } from "./agent/projectUnderstandingTask.js";
@@ -36,7 +36,8 @@ export async function main(): Promise<void> {
   program.command("edit <task...>").description("Run an edit task").action(async (task: string[]) => runOne(task.join(" "), program.opts<CliOpts>(), "edit"));
   program.command("review").description("Review current diff").action(async (_opts: CliOpts) => runOne("Review the current git diff for bugs, regressions, risks, and missing tests.", program.opts<CliOpts>(), "review"));
   program.command("learn-project").description("Inspect this project and write durable notes to GROK.md").action(async (_opts: CliOpts) => runOne(PROJECT_UNDERSTANDING_TASK, program.opts<CliOpts>(), "learn-project"));
-  program.command("status").description("Show git status").action(async () => localStatus("status"));
+  program.command("status").description("Show session status").action(() => localSessionStatus(program.opts<CliOpts>()));
+  program.command("git-status").description("Show git status").action(async () => localGitStatus());
   program.command("diff").description("Show git diff").action(async () => localStatus("diff"));
   program.command("resume [sessionId]").description("Resume a session").action(async (sessionId?: string) => runResume(sessionId, program.opts<CliOpts>()));
 
@@ -115,6 +116,27 @@ async function runResume(sessionId: string | undefined, opts: CliOpts): Promise<
   const agent = await makeAgent({ ...opts, model: session.model, approval: session.approval }, session.taskSummary ?? "resume session");
   for (const item of session.contextItems) agent.context.add(item);
   await startRepl(agent);
+}
+
+function localSessionStatus(opts: CliOpts): void {
+  const toolOverrides = parseServerToolOverrides(process.argv.slice(2));
+  const config = loadConfig(process.cwd(), {
+    model: opts.model,
+    approval: opts.approval,
+    toolChoice: opts.toolChoice,
+    maxSteps: parseMaxSteps(opts.maxSteps),
+    serverTools: toolOverrides.serverTools,
+    enableWebSearch: toolOverrides.enableWebSearch,
+    enableXSearch: toolOverrides.enableXSearch
+  });
+  console.log(formatSessionStatus(config));
+}
+
+async function localGitStatus(): Promise<void> {
+  const config = loadConfig(process.cwd(), {});
+  const agent = new Agent({} as any, config, "git-status");
+  const result = await agent.tools.execute("git_status", {}, agent.toolContext());
+  console.log(JSON.stringify(result, null, 2));
 }
 
 async function localStatus(kind: "status" | "diff"): Promise<void> {

--- a/src/ui/repl.ts
+++ b/src/ui/repl.ts
@@ -7,6 +7,7 @@ import { colorDiff } from "./diffView.js";
 import { readInteractiveLine, runWithEscInterrupt } from "./interactiveInput.js";
 import { SLASH_COMMANDS } from "./slashCommands.js";
 import type { ApprovalMode } from "../config/loadConfig.js";
+import { formatSessionStatus } from "./terminal.js";
 
 export async function startRepl(agent: Agent): Promise<void> {
   console.log(chalk.dim("Type /help for commands, /exit to quit."));
@@ -34,6 +35,9 @@ async function handleSlash(command: string, agent: Agent): Promise<void> {
       console.log(SLASH_COMMANDS.map((cmd) => `${cmd.usage.padEnd(24)} ${cmd.description}`).join("\n"));
       break;
     case "/status":
+      console.log(formatSessionStatus(agent.config));
+      break;
+    case "/git-status":
       console.log(JSON.stringify(await agent.tools.execute("git_status", {}, agent.toolContext()), null, 2));
       break;
     case "/diff":

--- a/src/ui/slashCommands.ts
+++ b/src/ui/slashCommands.ts
@@ -6,7 +6,8 @@ export type SlashCommand = {
 
 export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/help", usage: "/help", description: "Show available commands." },
-  { name: "/status", usage: "/status", description: "Show git status." },
+  { name: "/status", usage: "/status", description: "Show session status." },
+  { name: "/git-status", usage: "/git-status", description: "Show git status." },
   { name: "/diff", usage: "/diff", description: "Show git-style diff for current changes." },
   { name: "/approval", usage: "/approval", description: "Choose approval mode from a menu." },
   { name: "/model", usage: "/model <model>", description: "Show model change guidance." },

--- a/src/ui/terminal.ts
+++ b/src/ui/terminal.ts
@@ -1,8 +1,22 @@
 import chalk from "chalk";
+import type { GrokCodeConfig } from "../config/loadConfig.js";
 
 export function printHeader(model: string, workspace: string): void {
   console.log(chalk.bold("grok-code"));
   console.log(chalk.dim(`model ${model} | workspace ${workspace}`));
+}
+
+export function formatSessionStatus(config: GrokCodeConfig): string {
+  return [
+    `model:        ${config.model}`,
+    `provider:     xAI`,
+    `workspace:    ${config.workspaceRoot}`,
+    `approval:     ${config.approval}`,
+    `tool choice:  ${config.toolChoice}`,
+    `max steps:    ${config.maxSteps}`,
+    `web search:   ${config.serverTools && config.enableWebSearch ? "enabled" : "disabled"}`,
+    `x search:     ${config.serverTools && config.enableXSearch ? "enabled" : "disabled"}`
+  ].join("\n");
 }
 
 export function printError(error: unknown): void {


### PR DESCRIPTION
## Summary

Fixes #27.

- Change `grok-code status` and `/status` to show session/runtime status, including model, provider, workspace, approval mode, tool choice, and search settings.
- Add `grok-code git-status` and `/git-status` for the existing Git status behavior.
- Update README command documentation.

## Verification

- `npm run build`
- `node dist/index.js status`
- `node dist/index.js git-status`
- `npm test`