### PR TITLE
Add workspace trust menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Run `grok-code` with no task to enter interactive mode.
 - Press Enter to accept and run the highlighted command.
 - Press Esc while editing the prompt to cancel the command menu and clear the current input.
 - Press Esc while a model request is running to interrupt the current request.
+- `/cd`, `/workspace`, and `/change-dir` switch the active workspace through a menu.
+- `/trust`, `/trust-settings`, and `/workspace-trust` view, change, or clear remembered workspace trust settings.
 - `/skills` shows skills loaded for the current interactive baseline separately from skills that are available and loaded only when triggered.
 - `/approval <mode>` changes approval mode during interactive sessions.
 
@@ -82,6 +84,8 @@ Useful slash commands:
 ```txt
 /help
 /status
+/cd
+/trust
 /git-status
 /diff
 /approval <mode>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,7 @@ import { formatSessionStatus, printHeader } from "./ui/terminal.js";
 import { SessionStore } from "./session/SessionStore.js";
 import { colorDiff } from "./ui/diffView.js";
 import { PROJECT_UNDERSTANDING_TASK } from "./agent/projectUnderstandingTask.js";
+import { ensureWorkspaceTrusted } from "./ui/workspaceTrust.js";
 
 type CliOpts = {
   model?: string;
@@ -50,9 +51,9 @@ export async function main(): Promise<void> {
   await program.parseAsync(process.argv);
 }
 
-async function makeAgent(opts: CliOpts, task = ""): Promise<Agent> {
+async function makeAgent(opts: CliOpts, task = "", cwd = process.cwd()): Promise<Agent> {
   const toolOverrides = parseServerToolOverrides(process.argv.slice(2));
-  const config = loadConfig(process.cwd(), {
+  const config = loadConfig(cwd, {
     model: opts.model,
     approval: opts.approval,
     toolChoice: opts.toolChoice,
@@ -104,18 +105,33 @@ async function runOne(task: string, opts: CliOpts, _kind: string): Promise<void>
 }
 
 async function runInteractive(opts: CliOpts): Promise<void> {
+  if (!(await ensureWorkspaceTrusted(process.cwd()))) return;
   const agent = await makeAgent(opts, "interactive session");
-  await startRepl(agent);
-  await agent.background.stopAll("interactive exit cleanup");
+  const finalAgent = await startRepl(agent, {
+    switchWorkspace: async (workspace) => {
+      const next = await makeAgent(opts, "interactive session", workspace);
+      process.chdir(workspace);
+      return next;
+    }
+  });
+  await finalAgent.background.stopAll("interactive exit cleanup");
 }
 
 async function runResume(sessionId: string | undefined, opts: CliOpts): Promise<void> {
+  if (!(await ensureWorkspaceTrusted(process.cwd()))) return;
   const store = new SessionStore(process.cwd());
   const session = store.load(sessionId);
   if (!session) throw new Error("No session found.");
   const agent = await makeAgent({ ...opts, model: session.model, approval: session.approval }, session.taskSummary ?? "resume session");
   for (const item of session.contextItems) agent.context.add(item);
-  await startRepl(agent);
+  const finalAgent = await startRepl(agent, {
+    switchWorkspace: async (workspace) => {
+      const next = await makeAgent({ ...opts, model: session.model, approval: session.approval }, "interactive session", workspace);
+      process.chdir(workspace);
+      return next;
+    }
+  });
+  await finalAgent.background.stopAll("resume exit cleanup");
 }
 
 function localSessionStatus(opts: CliOpts): void {

--- a/src/ui/repl.ts
+++ b/src/ui/repl.ts
@@ -8,8 +8,14 @@ import { readInteractiveLine, runWithEscInterrupt } from "./interactiveInput.js"
 import { SLASH_COMMANDS } from "./slashCommands.js";
 import type { ApprovalMode } from "../config/loadConfig.js";
 import { formatSessionStatus } from "./terminal.js";
+import { chooseWorkspace, formatWorkspaceTrustStatus, manageWorkspaceTrust } from "./workspaceTrust.js";
 
-export async function startRepl(agent: Agent): Promise<void> {
+type ReplOptions = {
+  switchWorkspace?: (workspace: string) => Promise<Agent>;
+};
+
+export async function startRepl(initialAgent: Agent, options: ReplOptions = {}): Promise<Agent> {
+  let agent = initialAgent;
   console.log(chalk.dim("Type /help for commands, /exit to quit."));
   for (;;) {
     const line = await readInteractiveLine("grok-code>");
@@ -17,7 +23,8 @@ export async function startRepl(agent: Agent): Promise<void> {
     if (!text) continue;
     if (text === "/exit") break;
     if (text.startsWith("/")) {
-      await handleSlash(text, agent);
+      const nextAgent = await handleSlash(text, agent, options);
+      if (nextAgent) agent = nextAgent;
       continue;
     }
     try {
@@ -26,16 +33,39 @@ export async function startRepl(agent: Agent): Promise<void> {
       console.log(chalk.yellow(error instanceof Error ? error.message : String(error)));
     }
   }
+  return agent;
 }
 
-async function handleSlash(command: string, agent: Agent): Promise<void> {
+async function handleSlash(command: string, agent: Agent, options: ReplOptions): Promise<Agent | void> {
   const [name, ...rest] = command.split(/\s+/);
   switch (name) {
     case "/help":
       console.log(SLASH_COMMANDS.map((cmd) => `${cmd.usage.padEnd(24)} ${cmd.description}`).join("\n"));
       break;
     case "/status":
-      console.log(formatSessionStatus(agent.config));
+      console.log([formatSessionStatus(agent.config), formatWorkspaceTrustStatus(agent.config.workspaceRoot)].join("\n"));
+      break;
+    case "/cd":
+    case "/workspace":
+    case "/change-dir": {
+      if (!options.switchWorkspace) {
+        console.log("Workspace switching is unavailable in this session.");
+        break;
+      }
+      const workspace = await chooseWorkspace(agent.config.workspaceRoot);
+      if (!workspace) {
+        console.log("Workspace unchanged.");
+        break;
+      }
+      await agent.background.stopAll("workspace switch cleanup");
+      const nextAgent = await options.switchWorkspace(workspace);
+      console.log(`Workspace switched to ${nextAgent.config.workspaceRoot}`);
+      return nextAgent;
+    }
+    case "/trust":
+    case "/trust-settings":
+    case "/workspace-trust":
+      console.log(await manageWorkspaceTrust(agent.config.workspaceRoot));
       break;
     case "/git-status":
       console.log(JSON.stringify(await agent.tools.execute("git_status", {}, agent.toolContext()), null, 2));

--- a/src/ui/slashCommands.ts
+++ b/src/ui/slashCommands.ts
@@ -7,6 +7,12 @@ export type SlashCommand = {
 export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/help", usage: "/help", description: "Show available commands." },
   { name: "/status", usage: "/status", description: "Show session status." },
+  { name: "/cd", usage: "/cd", description: "Change workspace directory from a menu." },
+  { name: "/workspace", usage: "/workspace", description: "Change workspace directory from a menu." },
+  { name: "/change-dir", usage: "/change-dir", description: "Change workspace directory from a menu." },
+  { name: "/trust", usage: "/trust", description: "View or change workspace trust settings." },
+  { name: "/trust-settings", usage: "/trust-settings", description: "View or change workspace trust settings." },
+  { name: "/workspace-trust", usage: "/workspace-trust", description: "View or change workspace trust settings." },
   { name: "/git-status", usage: "/git-status", description: "Show git status." },
   { name: "/diff", usage: "/diff", description: "Show git-style diff for current changes." },
   { name: "/approval", usage: "/approval", description: "Choose approval mode from a menu." },

--- a/src/ui/workspaceTrust.ts
+++ b/src/ui/workspaceTrust.ts
@@ -42,6 +42,7 @@ export async function chooseWorkspace(currentWorkspace: string, store = new Work
         ? await askDirectory("Workspace path", currentWorkspace)
         : choice.slice("recent:".length);
   if (!selected) return null;
+  if (sameDirectory(selected, currentWorkspace)) return null;
   const trusted = await ensureWorkspaceTrusted(selected, store);
   if (!trusted) return null;
   const confirmed = await confirmMenu(`Switch workspace to ${selected}?`);
@@ -139,4 +140,12 @@ function formatTrustPreview(workspace: string, scope: WorkspaceTrustScope, base?
 
 function formatEntry(entry: WorkspaceTrustEntry): string {
   return `workspace trust: ${describeTrustEntry(entry)}`;
+}
+
+function sameDirectory(left: string, right: string): boolean {
+  try {
+    return fs.realpathSync(left) === fs.realpathSync(right);
+  } catch {
+    return path.resolve(left) === path.resolve(right);
+  }
 }

--- a/src/ui/workspaceTrust.ts
+++ b/src/ui/workspaceTrust.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import path from "node:path";
+import chalk from "chalk";
+import { input, select } from "@inquirer/prompts";
+import { WorkspaceTrustStore, describeTrustEntry, type WorkspaceTrustEntry, type WorkspaceTrustScope } from "../workspace/WorkspaceTrustStore.js";
+
+export async function ensureWorkspaceTrusted(workspace: string, store = new WorkspaceTrustStore()): Promise<boolean> {
+  const existing = store.getTrustFor(workspace);
+  if (existing) {
+    store.rememberWorkspace(workspace);
+    return true;
+  }
+
+  const scope = await chooseTrustScope(`This directory has not been trusted yet:\n${workspace}\n\nWhat would you like to trust?`);
+  if (scope === "cancel") return false;
+  const base = scope === "custom-descendants" ? await askDirectory("Trusted base directory", path.dirname(workspace)) : undefined;
+  if (base === null) return false;
+  const confirmed = await confirmMenu(`Apply trust setting: ${formatTrustPreview(workspace, scope, base)}?`);
+  if (!confirmed) return false;
+  store.setTrust(workspace, scope, base);
+  return true;
+}
+
+export async function chooseWorkspace(currentWorkspace: string, store = new WorkspaceTrustStore()): Promise<string | null> {
+  const recent = store.recentWorkspaces().filter((item) => item !== currentWorkspace);
+  const choice = await select<string>({
+    message: `Change workspace (current: ${currentWorkspace})`,
+    choices: [
+      { name: "Current directory", value: "current" },
+      { name: "Parent directory", value: "parent" },
+      ...recent.map((workspace) => ({ name: workspace, value: `recent:${workspace}` })),
+      { name: "Manually enter a path", value: "manual" },
+      { name: "Cancel", value: "cancel" }
+    ]
+  });
+  if (choice === "cancel") return null;
+  const selected = choice === "current"
+    ? currentWorkspace
+    : choice === "parent"
+      ? path.dirname(currentWorkspace)
+      : choice === "manual"
+        ? await askDirectory("Workspace path", currentWorkspace)
+        : choice.slice("recent:".length);
+  if (!selected) return null;
+  const trusted = await ensureWorkspaceTrusted(selected, store);
+  if (!trusted) return null;
+  const confirmed = await confirmMenu(`Switch workspace to ${selected}?`);
+  return confirmed ? selected : null;
+}
+
+export async function manageWorkspaceTrust(workspace: string, store = new WorkspaceTrustStore()): Promise<string> {
+  for (;;) {
+    const current = store.getTrustFor(workspace);
+    const action = await select<string>({
+      message: [
+        `Current workspace: ${workspace}`,
+        `Current trust setting: ${current ? describeTrustEntry(current) : "none"}`
+      ].join("\n"),
+      choices: [
+        { name: "Keep current setting", value: "keep" },
+        { name: "Change trust scope", value: "change" },
+        { name: "Change trusted base directory", value: "base", disabled: current?.scope === "custom-descendants" ? false : "Only available for custom base trust" },
+        { name: "Clear remembered trust setting", value: "clear" },
+        { name: "Cancel", value: "cancel" }
+      ]
+    });
+    if (action === "keep" || action === "cancel") return "Trust settings unchanged.";
+    if (action === "clear") {
+      const confirmed = await confirmMenu("Clear remembered trust setting for this workspace?");
+      if (!confirmed) continue;
+      return store.clearTrust(workspace) ? "Trust setting cleared." : "No trust setting was stored for this workspace.";
+    }
+    if (action === "base" && current?.scope === "custom-descendants") {
+      const base = await askDirectory("Trusted base directory", current.baseDirectory ?? path.dirname(workspace));
+      if (!base) continue;
+      const confirmed = await confirmMenu(`Apply trust setting: ${formatTrustPreview(workspace, "custom-descendants", base)}?`);
+      if (!confirmed) continue;
+      const updated = store.setTrust(workspace, "custom-descendants", base);
+      return `Trust setting updated: ${describeTrustEntry(updated)}`;
+    }
+    if (action === "change") {
+      const scope = await chooseTrustScope("Choose trust scope");
+      if (scope === "cancel") continue;
+      const base = scope === "custom-descendants" ? await askDirectory("Trusted base directory", path.dirname(workspace)) : undefined;
+      if (base === null) continue;
+      const confirmed = await confirmMenu(`Apply trust setting: ${formatTrustPreview(workspace, scope, base)}?`);
+      if (!confirmed) continue;
+      const updated = store.setTrust(workspace, scope, base);
+      return `Trust setting updated: ${describeTrustEntry(updated)}`;
+    }
+  }
+}
+
+export function formatWorkspaceTrustStatus(workspace: string, store = new WorkspaceTrustStore()): string {
+  const entry = store.getTrustFor(workspace);
+  return entry ? formatEntry(entry) : "workspace trust: none";
+}
+
+async function chooseTrustScope(message: string): Promise<WorkspaceTrustScope | "cancel"> {
+  return select<WorkspaceTrustScope | "cancel">({
+    message,
+    choices: [
+      { name: "Trust only the current directory", value: "exact" },
+      { name: "Trust the current directory and all subdirectories", value: "descendants" },
+      { name: "Trust all subdirectories under a specified directory", value: "custom-descendants" },
+      { name: "Do not trust / cancel", value: "cancel" }
+    ]
+  });
+}
+
+async function askDirectory(message: string, defaultValue: string): Promise<string | null> {
+  const raw = await input({ message, default: defaultValue });
+  const resolved = path.resolve(raw.trim() || defaultValue);
+  if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
+    console.log(chalk.yellow(`Not a directory: ${resolved}`));
+    return null;
+  }
+  return fs.realpathSync(resolved);
+}
+
+async function confirmMenu(message: string): Promise<boolean> {
+  return select<boolean>({
+    message,
+    choices: [
+      { name: "Apply", value: true },
+      { name: "Cancel", value: false }
+    ]
+  });
+}
+
+function formatTrustPreview(workspace: string, scope: WorkspaceTrustScope, base?: string): string {
+  return describeTrustEntry({
+    workspace,
+    scope,
+    ...(base ? { baseDirectory: base } : {}),
+    updatedAt: new Date().toISOString()
+  });
+}
+
+function formatEntry(entry: WorkspaceTrustEntry): string {
+  return `workspace trust: ${describeTrustEntry(entry)}`;
+}

--- a/src/workspace/WorkspaceTrustStore.ts
+++ b/src/workspace/WorkspaceTrustStore.ts
@@ -143,7 +143,10 @@ function addRecent(items: string[], workspace: string): string[] {
 }
 
 function samePath(left: string, right: string): boolean {
-  return path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase();
+  const resolvedLeft = path.resolve(left);
+  const resolvedRight = path.resolve(right);
+  if (process.platform === "win32") return resolvedLeft.toLowerCase() === resolvedRight.toLowerCase();
+  return resolvedLeft === resolvedRight;
 }
 
 function isInsideOrSame(child: string, parent: string): boolean {

--- a/src/workspace/WorkspaceTrustStore.ts
+++ b/src/workspace/WorkspaceTrustStore.ts
@@ -1,0 +1,161 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export type WorkspaceTrustScope = "exact" | "descendants" | "custom-descendants";
+
+export type WorkspaceTrustEntry = {
+  workspace: string;
+  scope: WorkspaceTrustScope;
+  baseDirectory?: string;
+  updatedAt: string;
+};
+
+type TrustFile = {
+  version: 1;
+  entries: WorkspaceTrustEntry[];
+  recentWorkspaces: string[];
+};
+
+export class WorkspaceTrustStore {
+  constructor(private readonly filePath = defaultTrustPath()) {}
+
+  getTrustFor(workspace: string): WorkspaceTrustEntry | undefined {
+    const target = normalizeExistingDirectory(workspace);
+    const entries = this.read().entries
+      .filter((entry) => trustsDirectory(entry, target))
+      .sort((a, b) => trustSpecificity(b) - trustSpecificity(a));
+    return entries[0];
+  }
+
+  setTrust(workspace: string, scope: WorkspaceTrustScope, baseDirectory?: string): WorkspaceTrustEntry {
+    const target = normalizeExistingDirectory(workspace);
+    const base = scope === "custom-descendants"
+      ? normalizeExistingDirectory(baseDirectory ?? workspace)
+      : scope === "descendants"
+        ? target
+        : undefined;
+    const entry: WorkspaceTrustEntry = {
+      workspace: target,
+      scope,
+      ...(base ? { baseDirectory: base } : {}),
+      updatedAt: new Date().toISOString()
+    };
+    const data = this.read();
+    data.entries = data.entries.filter((item) => item.workspace !== target);
+    data.entries.push(entry);
+    data.recentWorkspaces = addRecent(data.recentWorkspaces, target);
+    this.write(data);
+    return entry;
+  }
+
+  clearTrust(workspace: string): boolean {
+    const target = normalizeExistingDirectory(workspace);
+    const data = this.read();
+    const next = data.entries.filter((item) => item.workspace !== target);
+    const changed = next.length !== data.entries.length;
+    if (changed) {
+      data.entries = next;
+      this.write(data);
+    }
+    return changed;
+  }
+
+  rememberWorkspace(workspace: string): void {
+    const target = normalizeExistingDirectory(workspace);
+    const data = this.read();
+    data.recentWorkspaces = addRecent(data.recentWorkspaces, target);
+    this.write(data);
+  }
+
+  recentWorkspaces(limit = 8): string[] {
+    return this.read().recentWorkspaces.filter((item) => directoryExists(item)).slice(0, limit);
+  }
+
+  describe(workspace: string): string {
+    const entry = this.getTrustFor(workspace);
+    return entry ? describeTrustEntry(entry) : "No remembered trust setting.";
+  }
+
+  private read(): TrustFile {
+    if (!fs.existsSync(this.filePath)) return emptyTrustFile();
+    try {
+      const parsed = JSON.parse(fs.readFileSync(this.filePath, "utf8")) as Partial<TrustFile>;
+      return {
+        version: 1,
+        entries: Array.isArray(parsed.entries) ? parsed.entries.filter(isTrustEntry) : [],
+        recentWorkspaces: Array.isArray(parsed.recentWorkspaces) ? parsed.recentWorkspaces.filter(directoryExists) : []
+      };
+    } catch {
+      return emptyTrustFile();
+    }
+  }
+
+  private write(data: TrustFile): void {
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
+    fs.writeFileSync(this.filePath, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+  }
+}
+
+export function defaultTrustPath(): string {
+  const home = os.homedir();
+  return path.join(home, ".grok-code", "trust.json");
+}
+
+export function describeTrustEntry(entry: WorkspaceTrustEntry): string {
+  if (entry.scope === "exact") return `Trust only ${entry.workspace}`;
+  const base = entry.baseDirectory ?? entry.workspace;
+  return `Trust ${base} and all subdirectories`;
+}
+
+function emptyTrustFile(): TrustFile {
+  return { version: 1, entries: [], recentWorkspaces: [] };
+}
+
+function trustsDirectory(entry: WorkspaceTrustEntry, workspace: string): boolean {
+  if (entry.scope === "exact") return samePath(entry.workspace, workspace);
+  const base = entry.baseDirectory ?? entry.workspace;
+  return isInsideOrSame(workspace, base);
+}
+
+function trustSpecificity(entry: WorkspaceTrustEntry): number {
+  const base = entry.scope === "exact" ? entry.workspace : entry.baseDirectory ?? entry.workspace;
+  return base.length + (entry.scope === "exact" ? 1000 : 0);
+}
+
+function normalizeExistingDirectory(input: string): string {
+  const abs = path.resolve(input);
+  const real = fs.realpathSync(abs);
+  if (!fs.statSync(real).isDirectory()) throw new Error(`Not a directory: ${input}`);
+  return real;
+}
+
+function directoryExists(input: string): boolean {
+  try {
+    return fs.statSync(input).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function addRecent(items: string[], workspace: string): string[] {
+  return [workspace, ...items.filter((item) => !samePath(item, workspace))].slice(0, 20);
+}
+
+function samePath(left: string, right: string): boolean {
+  return path.resolve(left).toLowerCase() === path.resolve(right).toLowerCase();
+}
+
+function isInsideOrSame(child: string, parent: string): boolean {
+  const relative = path.relative(parent, child);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function isTrustEntry(value: unknown): value is WorkspaceTrustEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as WorkspaceTrustEntry;
+  return typeof entry.workspace === "string"
+    && (entry.scope === "exact" || entry.scope === "descendants" || entry.scope === "custom-descendants")
+    && typeof entry.updatedAt === "string"
+    && directoryExists(entry.workspace);
+}

--- a/tests/workspaceTrustStore.test.mjs
+++ b/tests/workspaceTrustStore.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { WorkspaceTrustStore, describeTrustEntry } from "../dist/workspace/WorkspaceTrustStore.js";
+
+test("exact trust applies only to the selected directory", () => {
+  const { store, root, child } = makeStore();
+  store.setTrust(root, "exact");
+
+  assert.equal(store.getTrustFor(root)?.scope, "exact");
+  assert.equal(store.getTrustFor(child), undefined);
+});
+
+test("descendant trust applies to subdirectories and records recent workspaces", () => {
+  const { store, root, child } = makeStore();
+  store.setTrust(root, "descendants");
+
+  assert.equal(store.getTrustFor(child)?.scope, "descendants");
+  assert.deepEqual(store.recentWorkspaces(1), [fs.realpathSync(root)]);
+});
+
+test("custom descendant trust uses the selected base directory", () => {
+  const { store, base, root, sibling } = makeStore();
+  const entry = store.setTrust(root, "custom-descendants", base);
+
+  assert.equal(store.getTrustFor(sibling)?.scope, "custom-descendants");
+  assert.equal(store.getTrustFor(sibling)?.baseDirectory, fs.realpathSync(base));
+  assert.equal(describeTrustEntry(entry), `Trust ${fs.realpathSync(base)} and all subdirectories`);
+});
+
+test("clearing trust removes the remembered entry for that workspace", () => {
+  const { store, root } = makeStore();
+  store.setTrust(root, "exact");
+
+  assert.equal(store.clearTrust(root), true);
+  assert.equal(store.getTrustFor(root), undefined);
+  assert.equal(store.clearTrust(root), false);
+});
+
+function makeStore() {
+  const base = fs.mkdtempSync(path.join(os.tmpdir(), "grok-trust-"));
+  const root = path.join(base, "project");
+  const child = path.join(root, "child");
+  const sibling = path.join(base, "sibling");
+  fs.mkdirSync(child, { recursive: true });
+  fs.mkdirSync(sibling);
+  const store = new WorkspaceTrustStore(path.join(base, "trust.json"));
+  return { store, base, root, child, sibling };
+}


### PR DESCRIPTION
## Summary

- add persisted workspace trust settings with exact, descendants, and custom-base scopes
- prompt for trust scope when entering interactive or resume mode from an untrusted workspace
- add menu-based workspace switching commands (`/cd`, `/workspace`, `/change-dir`) and trust settings commands (`/trust`, `/trust-settings`, `/workspace-trust`)
- document the new interactive commands and add trust store tests

Closes #29

## Tests

- `npm run build`
- `npm test`