### PR TITLE
Fix workspace trust follow-ups

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,8 @@ type CliOpts = {
   xSearch?: boolean;
 };
 
+let activeSigintCleanup: (() => void) | undefined;
+
 export async function main(): Promise<void> {
   const program = new Command();
   program
@@ -66,10 +68,16 @@ async function makeAgent(opts: CliOpts, task = "", cwd = process.cwd()): Promise
   const agent = new Agent(client, config, task);
   printHeader(config.model, config.workspaceRoot);
   await agent.bootstrap();
-  process.once("SIGINT", async () => {
+  activeSigintCleanup?.();
+  const sigintHandler = async () => {
     await agent.background.stopAll("Ctrl+C cleanup");
     process.exit(130);
-  });
+  };
+  process.once("SIGINT", sigintHandler);
+  activeSigintCleanup = () => {
+    process.removeListener("SIGINT", sigintHandler);
+    activeSigintCleanup = undefined;
+  };
   return agent;
 }
 

--- a/src/ui/workspaceTrust.ts
+++ b/src/ui/workspaceTrust.ts
@@ -67,9 +67,10 @@ export async function manageWorkspaceTrust(workspace: string, store = new Worksp
     });
     if (action === "keep" || action === "cancel") return "Trust settings unchanged.";
     if (action === "clear") {
-      const confirmed = await confirmMenu("Clear remembered trust setting for this workspace?");
+      if (!current) return "No trust setting was stored for this workspace.";
+      const confirmed = await confirmMenu(`Clear remembered trust setting: ${describeTrustEntry(current)}?`);
       if (!confirmed) continue;
-      return store.clearTrust(workspace) ? "Trust setting cleared." : "No trust setting was stored for this workspace.";
+      return store.clearTrustEntry(current) ? "Trust setting cleared." : "No trust setting was stored for this workspace.";
     }
     if (action === "base" && current?.scope === "custom-descendants") {
       const base = await askDirectory("Trusted base directory", current.baseDirectory ?? path.dirname(workspace));

--- a/src/workspace/WorkspaceTrustStore.ts
+++ b/src/workspace/WorkspaceTrustStore.ts
@@ -51,8 +51,16 @@ export class WorkspaceTrustStore {
 
   clearTrust(workspace: string): boolean {
     const target = normalizeExistingDirectory(workspace);
+    return this.clearTrustWorkspace(target);
+  }
+
+  clearTrustEntry(entry: WorkspaceTrustEntry): boolean {
+    return this.clearTrustWorkspace(entry.workspace);
+  }
+
+  private clearTrustWorkspace(workspace: string): boolean {
     const data = this.read();
-    const next = data.entries.filter((item) => item.workspace !== target);
+    const next = data.entries.filter((item) => item.workspace !== workspace);
     const changed = next.length !== data.entries.length;
     if (changed) {
       data.entries = next;

--- a/tests/workspaceTrustStore.test.mjs
+++ b/tests/workspaceTrustStore.test.mjs
@@ -39,6 +39,16 @@ test("clearing trust removes the remembered entry for that workspace", () => {
   assert.equal(store.clearTrust(root), false);
 });
 
+test("clearing a matched trust entry removes inherited trust", () => {
+  const { store, root, child } = makeStore();
+  store.setTrust(root, "descendants");
+  const inherited = store.getTrustFor(child);
+
+  assert.equal(inherited?.scope, "descendants");
+  assert.equal(store.clearTrustEntry(inherited), true);
+  assert.equal(store.getTrustFor(child), undefined);
+});
+
 function makeStore() {
   const base = fs.mkdtempSync(path.join(os.tmpdir(), "grok-trust-"));
   const root = path.join(base, "project");


### PR DESCRIPTION
## Summary

- replace stale SIGINT cleanup handlers when interactive workspace switches create new agents
- clear the matched trust entry when `/trust` is invoked from a workspace inheriting trust from an ancestor
- add coverage for clearing inherited workspace trust

Follow-up to #30 after the merged PR received additional review comments.

## Tests

- `npm test`