### PR TITLE
Add task-scoped sandbox profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Global flags:
 ```bash
 --model <model>
 --approval <on-request|auto-local|auto-safe|auto-all|never>
+--profile <default|build|test|debug|package|docs>
 --tool-choice <auto|required|none>
 --max-steps <number>
 --no-server-tools
@@ -256,7 +257,18 @@ If you deny and choose another approach, Grok Code asks for guidance and returns
 
 ## Sandbox Limitations
 
-Local tools can only read and write inside the workspace root. The sandbox rejects `.git` internals, `node_modules`, build outputs, coverage, minified generated files, binary files, and `.env` secrets unless explicitly necessary and allowed by tool policy.
+Local tools can only read and write inside the workspace root. The sandbox always rejects sensitive paths such as `.git` internals, `node_modules`, `.env` secrets, credentials, private keys, minified generated files, and binary files.
+
+Sandbox profiles allow read access to common generated outputs for task-specific workflows while keeping sensitive paths hard-denied:
+
+- `default`: source-oriented access; generated outputs stay denied.
+- `build`: allows common build outputs such as `build`, `dist`, `out`, `target`, `.next`, and generated source directories.
+- `test`: allows test reports and coverage directories such as `coverage`, `reports`, `test-results`, `junit`, and `.nyc_output`.
+- `debug`: allows common logs, reports, temp directories, and build/test outputs needed for diagnosis.
+- `package`: allows package/artifact output directories such as `dist`, `build`, `out`, `target`, and `artifacts`.
+- `docs`: allows common generated docs output directories.
+
+Approved shell commands that create a common generated output directory during the current session also make that directory readable for the remainder of the session. Sandbox block errors include the blocking rule, path, operation, active profile, and suggested profile when applicable.
 
 ## Examples
 
@@ -264,6 +276,12 @@ Fix failing tests:
 
 ```bash
 grok-code --approval auto-safe "fix the failing unit test"
+```
+
+Build and inspect generated output:
+
+```bash
+grok-code --approval auto-local --profile build "build the project and summarize any failures"
 ```
 
 Review a diff:

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -20,7 +20,7 @@ export class Agent {
   readonly skillLoader: SkillLoader;
 
   constructor(private readonly client: OpenAI, readonly config: GrokCodeConfig, originalTask = "") {
-    this.sandbox = new WorkspaceSandbox(config.workspaceRoot);
+    this.sandbox = new WorkspaceSandbox(config.workspaceRoot, config.sandboxProfile);
     this.approval = new ApprovalPolicy(config.approval, originalTask);
     this.toolSkills = new ToolSkillRegistry(config.workspaceRoot);
     this.toolSkills.loadBuiltin(LOCAL_TOOL_NAMES);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { createXaiClient } from "./api/xaiClient.js";
 import { Agent } from "./agent/Agent.js";
-import { loadConfig, type ApprovalMode, type ToolChoice } from "./config/loadConfig.js";
+import { loadConfig, type ApprovalMode, type SandboxProfile, type ToolChoice } from "./config/loadConfig.js";
 import { startRepl } from "./ui/repl.js";
 import { formatSessionStatus, printHeader } from "./ui/terminal.js";
 import { SessionStore } from "./session/SessionStore.js";
@@ -12,6 +12,7 @@ import { ensureWorkspaceTrusted } from "./ui/workspaceTrust.js";
 type CliOpts = {
   model?: string;
   approval?: ApprovalMode;
+  profile?: SandboxProfile;
   toolChoice?: ToolChoice;
   maxSteps?: string;
   serverTools?: boolean;
@@ -29,6 +30,7 @@ export async function main(): Promise<void> {
     .argument("[task...]", "Task description")
     .option("--model <model>", "Model", "grok-4.3")
     .option("--approval <mode>", "on-request|auto-local|auto-safe|auto-all|never", "on-request")
+    .option("--profile <profile>", "Sandbox profile: default|build|test|debug|package|docs", "default")
     .option("--tool-choice <choice>", "auto|required|none", "auto")
     .option("--max-steps <number>", "Maximum agent steps", "30")
     .option("--no-server-tools", "Disable xAI server-side tools")
@@ -58,6 +60,7 @@ async function makeAgent(opts: CliOpts, task = "", cwd = process.cwd()): Promise
   const config = loadConfig(cwd, {
     model: opts.model,
     approval: opts.approval,
+    sandboxProfile: parseSandboxProfile(opts.profile),
     toolChoice: opts.toolChoice,
     maxSteps: parseMaxSteps(opts.maxSteps),
     serverTools: toolOverrides.serverTools,
@@ -97,6 +100,15 @@ export function parseMaxSteps(value?: string): number | undefined {
     throw new Error("--max-steps must be a positive integer");
   }
   return parsed;
+}
+
+export function parseSandboxProfile(value?: string): SandboxProfile | undefined {
+  if (value === undefined) return undefined;
+  const profiles: SandboxProfile[] = ["default", "build", "test", "debug", "package", "docs"];
+  if (!profiles.includes(value as SandboxProfile)) {
+    throw new Error(`--profile must be one of: ${profiles.join(", ")}`);
+  }
+  return value as SandboxProfile;
 }
 
 async function runOne(task: string, opts: CliOpts, _kind: string): Promise<void> {
@@ -147,6 +159,7 @@ function localSessionStatus(opts: CliOpts): void {
   const config = loadConfig(process.cwd(), {
     model: opts.model,
     approval: opts.approval,
+    sandboxProfile: parseSandboxProfile(opts.profile),
     toolChoice: opts.toolChoice,
     maxSteps: parseMaxSteps(opts.maxSteps),
     serverTools: toolOverrides.serverTools,

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 
 export type ApprovalMode = "on-request" | "auto-local" | "auto-safe" | "auto-all" | "never";
 export type ToolChoice = "auto" | "required" | "none";
+export type SandboxProfile = "default" | "build" | "test" | "debug" | "package" | "docs";
 
 export type GrokCodeConfig = {
   model: string;
@@ -14,6 +15,7 @@ export type GrokCodeConfig = {
   enableWebSearch: boolean;
   enableXSearch: boolean;
   workspaceRoot: string;
+  sandboxProfile: SandboxProfile;
 };
 
 export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfig> = {}): GrokCodeConfig {
@@ -29,6 +31,7 @@ export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfi
     enableWebSearch: true,
     enableXSearch: true,
     workspaceRoot: cwd,
+    sandboxProfile: "default",
     ...projectConfig,
     ...cleanOverrides
   };

--- a/src/tools/definitions/listFiles.ts
+++ b/src/tools/definitions/listFiles.ts
@@ -16,9 +16,12 @@ export function listFilesTool(skills: ToolSkillRegistry) {
       const base = args.path ?? ".";
       ctx.sandbox.resolvePath(base);
       const pattern = args.glob ?? "**/*";
-      const ig = createIgnoreRules();
+      const ig = createIgnoreRules(ctx.sandbox.profile);
       const entries = await fg(pattern, { cwd: ctx.sandbox.resolvePath(base), dot: true, onlyFiles: true });
-      const files = entries.map((entry) => (base === "." ? entry : `${base.replace(/\\/g, "/")}/${entry}`)).filter((entry) => !ig.ignores(entry)).slice(0, args.maxResults ?? 200);
+      const files = entries
+        .map((entry) => (base === "." ? entry : `${base.replace(/\\/g, "/")}/${entry}`))
+        .filter((entry) => !ig.ignores(entry) && !ctx.sandbox.isPathDenied(entry, "read"))
+        .slice(0, args.maxResults ?? 200);
       ctx.context.add({ type: "search_result", content: `list_files ${base} ${pattern}\n${files.join("\n")}`, priority: 45, expiresAfterSteps: 3 });
       return { files, truncated: entries.length > files.length };
     }

--- a/src/tools/definitions/listFiles.ts
+++ b/src/tools/definitions/listFiles.ts
@@ -2,7 +2,6 @@ import fg from "fast-glob";
 import { z } from "zod";
 import { schemas } from "../toolSchemas.js";
 import { makeTool } from "./helpers.js";
-import { createIgnoreRules } from "../../workspace/IgnoreRules.js";
 import type { ToolSkillRegistry } from "../../tool-skills/ToolSkillRegistry.js";
 
 export function listFilesTool(skills: ToolSkillRegistry) {
@@ -16,11 +15,10 @@ export function listFilesTool(skills: ToolSkillRegistry) {
       const base = args.path ?? ".";
       ctx.sandbox.resolvePath(base);
       const pattern = args.glob ?? "**/*";
-      const ig = createIgnoreRules(ctx.sandbox.profile);
-      const entries = await fg(pattern, { cwd: ctx.sandbox.resolvePath(base), dot: true, onlyFiles: true });
+      const entries = await fg(pattern, { cwd: ctx.sandbox.resolvePath(base), dot: true, onlyFiles: true, ignore: ["**/.git/**", "**/node_modules/**"] });
       const files = entries
         .map((entry) => (base === "." ? entry : `${base.replace(/\\/g, "/")}/${entry}`))
-        .filter((entry) => !ig.ignores(entry) && !ctx.sandbox.isPathDenied(entry, "read"))
+        .filter((entry) => !ctx.sandbox.isPathDenied(entry, "read"))
         .slice(0, args.maxResults ?? 200);
       ctx.context.add({ type: "search_result", content: `list_files ${base} ${pattern}\n${files.join("\n")}`, priority: 45, expiresAfterSteps: 3 });
       return { files, truncated: entries.length > files.length };

--- a/src/tools/definitions/runShell.ts
+++ b/src/tools/definitions/runShell.ts
@@ -1,7 +1,6 @@
 import { exec } from "node:child_process";
-import fs from "node:fs";
-import path from "node:path";
 import { promisify } from "node:util";
+import fg from "fast-glob";
 import { z } from "zod";
 import { schemas } from "../toolSchemas.js";
 import { makeTool, summarizeOutput } from "./helpers.js";
@@ -21,15 +20,15 @@ export function runShellTool(skills: ToolSkillRegistry) {
       const approval = await ctx.approval.approveCommand(args.command, args.reason);
       if (!approval.approved) throw new Error(approval.message ?? `Command rejected: ${approval.risk}`);
       const timeout = (args.timeoutSeconds ?? 120) * 1000;
-      const existingGeneratedDirs = snapshotGeneratedDirs(ctx.workspaceRoot);
+      const existingGeneratedDirs = await snapshotGeneratedDirs(ctx.workspaceRoot);
       try {
         const { stdout, stderr } = await execAsync(args.command, { cwd: ctx.workspaceRoot, timeout, maxBuffer: 5_000_000, windowsHide: true });
-        markNewGeneratedDirs(ctx, existingGeneratedDirs);
+        await markNewGeneratedDirs(ctx, existingGeneratedDirs);
         const output = summarizeOutput(`${stdout}${stderr ? `\n${stderr}` : ""}`);
         ctx.context.add({ type: "shell_output", content: `$ ${args.command}\n${output.text}`, priority: /test|build|lint|typecheck/i.test(args.command) ? 75 : 50, expiresAfterSteps: 2, source: { command: args.command } });
         return { command: args.command, exitCode: 0, stdout: output.text, truncated: output.truncated };
       } catch (error: any) {
-        markNewGeneratedDirs(ctx, existingGeneratedDirs);
+        await markNewGeneratedDirs(ctx, existingGeneratedDirs);
         const combined = `${error?.stdout ?? ""}${error?.stderr ? `\n${error.stderr}` : ""}${error?.message ? `\n${error.message}` : ""}`;
         const output = summarizeOutput(combined);
         ctx.context.add({ type: /test|build|lint|typecheck/i.test(args.command) ? "test_result" : "shell_output", content: `$ ${args.command}\n${output.text}`, priority: 80, expiresAfterSteps: 2, source: { command: args.command } });
@@ -39,19 +38,22 @@ export function runShellTool(skills: ToolSkillRegistry) {
   );
 }
 
-function snapshotGeneratedDirs(workspaceRoot: string): Set<string> {
-  const existing = new Set<string>();
-  for (const dir of GENERATED_OUTPUT_DIRS) {
-    const abs = path.join(workspaceRoot, dir);
-    if (directoryExists(abs)) existing.add(dir);
-  }
-  return existing;
+async function snapshotGeneratedDirs(workspaceRoot: string): Promise<Set<string>> {
+  const patterns = GENERATED_OUTPUT_DIRS.flatMap((dir) => [dir, `**/${dir}`]);
+  const matches = await fg(patterns, {
+    cwd: workspaceRoot,
+    dot: true,
+    onlyDirectories: true,
+    unique: true,
+    ignore: ["**/.git/**", "**/node_modules/**"]
+  });
+  return new Set(matches.map((entry) => entry.replace(/\\/g, "/")));
 }
 
-function markNewGeneratedDirs(ctx: any, before: Set<string>): void {
-  for (const dir of GENERATED_OUTPUT_DIRS) {
-    const abs = path.join(ctx.workspaceRoot, dir);
-    if (before.has(dir) || !directoryExists(abs)) continue;
+async function markNewGeneratedDirs(ctx: any, before: Set<string>): Promise<void> {
+  const after = await snapshotGeneratedDirs(ctx.workspaceRoot);
+  for (const dir of after) {
+    if (before.has(dir)) continue;
     ctx.sandbox.allowGeneratedOutputPath(dir);
     ctx.context.add({
       type: "environment_summary",
@@ -60,13 +62,5 @@ function markNewGeneratedDirs(ctx: any, before: Set<string>): void {
       expiresAfterSteps: 4,
       source: { command: "sandbox generated output tracking" }
     });
-  }
-}
-
-function directoryExists(absPath: string): boolean {
-  try {
-    return fs.statSync(absPath).isDirectory();
-  } catch {
-    return false;
   }
 }

--- a/src/tools/definitions/runShell.ts
+++ b/src/tools/definitions/runShell.ts
@@ -1,8 +1,11 @@
 import { exec } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import { promisify } from "node:util";
 import { z } from "zod";
 import { schemas } from "../toolSchemas.js";
 import { makeTool, summarizeOutput } from "./helpers.js";
+import { GENERATED_OUTPUT_DIRS } from "../../workspace/IgnoreRules.js";
 import type { ToolSkillRegistry } from "../../tool-skills/ToolSkillRegistry.js";
 
 const execAsync = promisify(exec);
@@ -18,12 +21,15 @@ export function runShellTool(skills: ToolSkillRegistry) {
       const approval = await ctx.approval.approveCommand(args.command, args.reason);
       if (!approval.approved) throw new Error(approval.message ?? `Command rejected: ${approval.risk}`);
       const timeout = (args.timeoutSeconds ?? 120) * 1000;
+      const existingGeneratedDirs = snapshotGeneratedDirs(ctx.workspaceRoot);
       try {
         const { stdout, stderr } = await execAsync(args.command, { cwd: ctx.workspaceRoot, timeout, maxBuffer: 5_000_000, windowsHide: true });
+        markNewGeneratedDirs(ctx, existingGeneratedDirs);
         const output = summarizeOutput(`${stdout}${stderr ? `\n${stderr}` : ""}`);
         ctx.context.add({ type: "shell_output", content: `$ ${args.command}\n${output.text}`, priority: /test|build|lint|typecheck/i.test(args.command) ? 75 : 50, expiresAfterSteps: 2, source: { command: args.command } });
         return { command: args.command, exitCode: 0, stdout: output.text, truncated: output.truncated };
       } catch (error: any) {
+        markNewGeneratedDirs(ctx, existingGeneratedDirs);
         const combined = `${error?.stdout ?? ""}${error?.stderr ? `\n${error.stderr}` : ""}${error?.message ? `\n${error.message}` : ""}`;
         const output = summarizeOutput(combined);
         ctx.context.add({ type: /test|build|lint|typecheck/i.test(args.command) ? "test_result" : "shell_output", content: `$ ${args.command}\n${output.text}`, priority: 80, expiresAfterSteps: 2, source: { command: args.command } });
@@ -31,4 +37,36 @@ export function runShellTool(skills: ToolSkillRegistry) {
       }
     }
   );
+}
+
+function snapshotGeneratedDirs(workspaceRoot: string): Set<string> {
+  const existing = new Set<string>();
+  for (const dir of GENERATED_OUTPUT_DIRS) {
+    const abs = path.join(workspaceRoot, dir);
+    if (directoryExists(abs)) existing.add(dir);
+  }
+  return existing;
+}
+
+function markNewGeneratedDirs(ctx: any, before: Set<string>): void {
+  for (const dir of GENERATED_OUTPUT_DIRS) {
+    const abs = path.join(ctx.workspaceRoot, dir);
+    if (before.has(dir) || !directoryExists(abs)) continue;
+    ctx.sandbox.allowGeneratedOutputPath(dir);
+    ctx.context.add({
+      type: "environment_summary",
+      content: `Generated output directory allowed for this session: ${dir}`,
+      priority: 60,
+      expiresAfterSteps: 4,
+      source: { command: "sandbox generated output tracking" }
+    });
+  }
+}
+
+function directoryExists(absPath: string): boolean {
+  try {
+    return fs.statSync(absPath).isDirectory();
+  } catch {
+    return false;
+  }
 }

--- a/src/tools/definitions/searchText.ts
+++ b/src/tools/definitions/searchText.ts
@@ -21,22 +21,22 @@ export function searchTextTool(skills: ToolSkillRegistry) {
       const max = args.maxResults ?? 100;
       const base = args.path ?? ".";
       ctx.sandbox.resolvePath(base);
-      const results = await (await commandExists("rg") ? rgSearch(ctx.workspaceRoot, args.query, base, args.glob, max) : nodeSearch(ctx, args.query, base, args.glob, max));
+      const results = await (await commandExists("rg") ? rgSearch(ctx, args.query, base, args.glob, max) : nodeSearch(ctx, args.query, base, args.glob, max));
       ctx.context.add({ type: "search_result", content: `search_text ${args.query}\n${results.map((r) => `${r.path}:${r.line}: ${r.preview}`).join("\n")}`, priority: 55, expiresAfterSteps: 3 });
       return { results };
     }
   );
 }
 
-async function rgSearch(root: string, query: string, base: string, glob: string | undefined, max: number) {
+async function rgSearch(ctx: any, query: string, base: string, glob: string | undefined, max: number) {
   const rgArgs = ["--line-number", "--fixed-strings", "--color", "never", query, base];
   if (glob) rgArgs.splice(0, 0, "--glob", glob);
   try {
-    const { stdout } = await execFileAsync("rg", rgArgs, { cwd: root, timeout: 30_000, maxBuffer: 2_000_000, windowsHide: true });
-    return stdout.split(/\r?\n/).filter(Boolean).slice(0, max).map((line) => {
+    const { stdout } = await execFileAsync("rg", rgArgs, { cwd: ctx.workspaceRoot, timeout: 30_000, maxBuffer: 2_000_000, windowsHide: true });
+    return stdout.split(/\r?\n/).filter(Boolean).map((line) => {
       const [file, lineNo, ...rest] = line.split(":");
       return { path: file ?? "", line: Number(lineNo), preview: rest.join(":").trim() };
-    });
+    }).filter((result) => !ctx.sandbox.isPathDenied(result.path, "read")).slice(0, max);
   } catch (error: any) {
     if (error?.code === 1) return [];
     throw error;
@@ -44,12 +44,12 @@ async function rgSearch(root: string, query: string, base: string, glob: string 
 }
 
 async function nodeSearch(ctx: any, query: string, base: string, glob: string | undefined, max: number) {
-  const ig = createIgnoreRules();
+  const ig = createIgnoreRules(ctx.sandbox.profile);
   const entries = await fg(glob ?? "**/*", { cwd: ctx.sandbox.resolvePath(base), onlyFiles: true, dot: true });
   const results: Array<{ path: string; line: number; preview: string }> = [];
   for (const entry of entries) {
     const rel = base === "." ? entry : `${base}/${entry}`;
-    if (ig.ignores(rel)) continue;
+    if (ig.ignores(rel) || ctx.sandbox.isPathDenied(rel, "read")) continue;
     let text = "";
     try { text = await fs.readFile(ctx.sandbox.assertReadableFile(rel), "utf8"); } catch { continue; }
     text.split(/\r?\n/).forEach((line, index) => {

--- a/src/tools/definitions/searchText.ts
+++ b/src/tools/definitions/searchText.ts
@@ -5,7 +5,6 @@ import fg from "fast-glob";
 import { z } from "zod";
 import { schemas } from "../toolSchemas.js";
 import { commandExists, makeTool } from "./helpers.js";
-import { createIgnoreRules } from "../../workspace/IgnoreRules.js";
 import type { ToolSkillRegistry } from "../../tool-skills/ToolSkillRegistry.js";
 
 const execFileAsync = promisify(execFile);
@@ -44,12 +43,11 @@ async function rgSearch(ctx: any, query: string, base: string, glob: string | un
 }
 
 async function nodeSearch(ctx: any, query: string, base: string, glob: string | undefined, max: number) {
-  const ig = createIgnoreRules(ctx.sandbox.profile);
-  const entries = await fg(glob ?? "**/*", { cwd: ctx.sandbox.resolvePath(base), onlyFiles: true, dot: true });
+  const entries = await fg(glob ?? "**/*", { cwd: ctx.sandbox.resolvePath(base), onlyFiles: true, dot: true, ignore: ["**/.git/**", "**/node_modules/**"] });
   const results: Array<{ path: string; line: number; preview: string }> = [];
   for (const entry of entries) {
     const rel = base === "." ? entry : `${base}/${entry}`;
-    if (ig.ignores(rel) || ctx.sandbox.isPathDenied(rel, "read")) continue;
+    if (ctx.sandbox.isPathDenied(rel, "read")) continue;
     let text = "";
     try { text = await fs.readFile(ctx.sandbox.assertReadableFile(rel), "utf8"); } catch { continue; }
     text.split(/\r?\n/).forEach((line, index) => {

--- a/src/ui/terminal.ts
+++ b/src/ui/terminal.ts
@@ -12,6 +12,7 @@ export function formatSessionStatus(config: GrokCodeConfig): string {
     `provider:     xAI`,
     `workspace:    ${config.workspaceRoot}`,
     `approval:     ${config.approval}`,
+    `profile:      ${config.sandboxProfile}`,
     `tool choice:  ${config.toolChoice}`,
     `max steps:    ${config.maxSteps}`,
     `web search:   ${config.serverTools && config.enableWebSearch ? "enabled" : "disabled"}`,

--- a/src/workspace/CodeSearch.ts
+++ b/src/workspace/CodeSearch.ts
@@ -113,9 +113,9 @@ export async function getRelatedFiles(sandbox: WorkspaceSandbox, filePath: strin
 }
 
 async function listSearchableFiles(sandbox: WorkspaceSandbox): Promise<string[]> {
-  const ig = createIgnoreRules();
+  const ig = createIgnoreRules(sandbox.profile);
   const entries = await fg(SOURCE_GLOBS, { cwd: sandbox.root, dot: true, onlyFiles: true });
-  return entries.filter((entry) => !ig.ignores(entry));
+  return entries.filter((entry) => !ig.ignores(entry) && !sandbox.isPathDenied(entry, "read"));
 }
 
 function scorePath(rel: string, query: string): number {

--- a/src/workspace/CodeSearch.ts
+++ b/src/workspace/CodeSearch.ts
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import fg from "fast-glob";
 import { getFileOverviewContent } from "./FileOverview.js";
-import { createIgnoreRules } from "./IgnoreRules.js";
 import { searchSymbols } from "./SymbolSearch.js";
 import type { WorkspaceSandbox } from "./WorkspaceSandbox.js";
 import type { RelatedFilesResult, SearchTreeResult } from "../tools/searchTreeInterfaces.js";
@@ -113,9 +112,8 @@ export async function getRelatedFiles(sandbox: WorkspaceSandbox, filePath: strin
 }
 
 async function listSearchableFiles(sandbox: WorkspaceSandbox): Promise<string[]> {
-  const ig = createIgnoreRules(sandbox.profile);
-  const entries = await fg(SOURCE_GLOBS, { cwd: sandbox.root, dot: true, onlyFiles: true });
-  return entries.filter((entry) => !ig.ignores(entry) && !sandbox.isPathDenied(entry, "read"));
+  const entries = await fg(SOURCE_GLOBS, { cwd: sandbox.root, dot: true, onlyFiles: true, ignore: ["**/.git/**", "**/node_modules/**"] });
+  return entries.filter((entry) => !sandbox.isPathDenied(entry, "read"));
 }
 
 function scorePath(rel: string, query: string): number {

--- a/src/workspace/IgnoreRules.ts
+++ b/src/workspace/IgnoreRules.ts
@@ -1,18 +1,51 @@
 import ignore from "ignore";
+import type { SandboxProfile } from "../config/loadConfig.js";
 
-export const DEFAULT_IGNORES = [
+export const HARD_DENY_PATTERNS = [
   ".git",
   "node_modules",
-  "dist",
-  "build",
-  ".next",
-  "coverage",
   "*.min.js",
   "*.min.css",
   ".env",
   ".env.*"
 ];
 
-export function createIgnoreRules(extra: string[] = []) {
-  return ignore().add([...DEFAULT_IGNORES, ...extra]);
+export const GENERATED_OUTPUT_DIRS = [
+  ".generated",
+  ".next",
+  ".nyc_output",
+  ".tmp",
+  "artifacts",
+  "build",
+  "coverage",
+  "dist",
+  "generated",
+  "junit",
+  "logs",
+  "out",
+  "reports",
+  "site",
+  "target",
+  "temp",
+  "test-results",
+  "tmp"
+];
+
+const PROFILE_ALLOWED_GENERATED_DIRS: Record<SandboxProfile, string[]> = {
+  default: [],
+  build: [".generated", ".next", "build", "dist", "generated", "out", "target", "tmp"],
+  test: [".nyc_output", "coverage", "junit", "reports", "test-results", "tmp"],
+  debug: [".generated", ".next", ".tmp", "build", "coverage", "dist", "logs", "out", "reports", "target", "temp", "test-results", "tmp"],
+  package: ["artifacts", "build", "dist", "out", "target", "tmp"],
+  docs: [".generated", "build", "dist", "generated", "out", "site", "tmp"]
+};
+
+export function generatedOutputDirsForProfile(profile: SandboxProfile): string[] {
+  return PROFILE_ALLOWED_GENERATED_DIRS[profile];
+}
+
+export function createIgnoreRules(profile: SandboxProfile = "default", extra: string[] = []) {
+  const allowed = new Set(generatedOutputDirsForProfile(profile));
+  const generatedDenied = GENERATED_OUTPUT_DIRS.filter((entry) => !allowed.has(entry));
+  return ignore().add([...HARD_DENY_PATTERNS, ...generatedDenied, ...extra]);
 }

--- a/src/workspace/SymbolSearch.ts
+++ b/src/workspace/SymbolSearch.ts
@@ -5,7 +5,7 @@ import { createIgnoreRules } from "./IgnoreRules.js";
 import type { WorkspaceSandbox } from "./WorkspaceSandbox.js";
 
 export async function searchSymbols(sandbox: WorkspaceSandbox, query: string, maxResults = 50) {
-  const ig = createIgnoreRules();
+  const ig = createIgnoreRules(sandbox.profile);
   const entries = await fg(["**/*.{ts,tsx,js,jsx,mts,cts}"], {
     cwd: sandbox.root,
     dot: true,
@@ -14,8 +14,8 @@ export async function searchSymbols(sandbox: WorkspaceSandbox, query: string, ma
   });
   const results: Array<{ name: string; kind: string; path: string; startLine: number; endLine?: number }> = [];
   for (const rel of entries) {
-    if (ig.ignores(rel)) continue;
-    const text = await fs.readFile(sandbox.resolvePath(rel), "utf8");
+    if (ig.ignores(rel) || sandbox.isPathDenied(rel, "read")) continue;
+    const text = await fs.readFile(sandbox.assertReadableFile(rel), "utf8");
     const overview = getFileOverviewContent(text);
     for (const symbol of overview.symbols) {
       if (symbol.name.toLowerCase().includes(query.toLowerCase())) {

--- a/src/workspace/SymbolSearch.ts
+++ b/src/workspace/SymbolSearch.ts
@@ -1,20 +1,18 @@
 import fs from "node:fs/promises";
 import fg from "fast-glob";
 import { getFileOverviewContent } from "./FileOverview.js";
-import { createIgnoreRules } from "./IgnoreRules.js";
 import type { WorkspaceSandbox } from "./WorkspaceSandbox.js";
 
 export async function searchSymbols(sandbox: WorkspaceSandbox, query: string, maxResults = 50) {
-  const ig = createIgnoreRules(sandbox.profile);
   const entries = await fg(["**/*.{ts,tsx,js,jsx,mts,cts}"], {
     cwd: sandbox.root,
     dot: true,
     onlyFiles: true,
-    ignore: []
+    ignore: ["**/.git/**", "**/node_modules/**"]
   });
   const results: Array<{ name: string; kind: string; path: string; startLine: number; endLine?: number }> = [];
   for (const rel of entries) {
-    if (ig.ignores(rel) || sandbox.isPathDenied(rel, "read")) continue;
+    if (sandbox.isPathDenied(rel, "read")) continue;
     const text = await fs.readFile(sandbox.assertReadableFile(rel), "utf8");
     const overview = getFileOverviewContent(text);
     for (const symbol of overview.symbols) {

--- a/src/workspace/WorkspaceSandbox.ts
+++ b/src/workspace/WorkspaceSandbox.ts
@@ -1,12 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
-import { DEFAULT_IGNORES } from "./IgnoreRules.js";
+import type { SandboxProfile } from "../config/loadConfig.js";
+import { GENERATED_OUTPUT_DIRS, generatedOutputDirsForProfile } from "./IgnoreRules.js";
+
+type SandboxOperation = "read" | "patch";
+type SandboxRule = "allowed" | "sensitive-path-denied" | "generated-output-read-denied" | "generated-output-patch-denied";
 
 export class WorkspaceSandbox {
   readonly root: string;
+  readonly profile: SandboxProfile;
+  private readonly sessionAllowedGeneratedRoots = new Set<string>();
 
-  constructor(root: string) {
+  constructor(root: string, profile: SandboxProfile = "default") {
     this.root = fs.realpathSync(root);
+    this.profile = profile;
   }
 
   resolvePath(inputPath = "."): string {
@@ -25,11 +32,11 @@ export class WorkspaceSandbox {
   assertReadableFile(inputPath: string): string {
     const abs = this.resolvePath(inputPath);
     const rel = this.relative(abs);
-    if (isDeniedPath(rel)) throw new Error(`Path is denied by sandbox: ${rel}`);
+    this.assertAllowedPath(rel, "read");
     const realAbs = fs.realpathSync(abs);
     if (!isInside(realAbs, this.root)) throw new Error(`Path escapes workspace: ${inputPath}`);
     const realRel = this.relative(realAbs);
-    if (isDeniedPath(realRel)) throw new Error(`Path is denied by sandbox: ${realRel}`);
+    this.assertAllowedPath(realRel, "read");
     const stat = fs.statSync(realAbs);
     if (!stat.isFile()) throw new Error(`Not a file: ${rel}`);
     if (looksBinary(realAbs)) throw new Error(`Binary file rejected: ${rel}`);
@@ -39,9 +46,43 @@ export class WorkspaceSandbox {
   assertWritablePatchPath(inputPath: string): string {
     const abs = this.resolveWritablePath(inputPath);
     const rel = this.relative(abs);
-    if (isDeniedPath(rel)) throw new Error(`Patch target denied by sandbox: ${rel}`);
+    this.assertAllowedPath(rel, "patch");
     assertNoSymlinkPathComponents(abs, this.root, inputPath);
     return abs;
+  }
+
+  allowGeneratedOutputPath(inputPath: string): void {
+    const abs = fs.realpathSync(path.resolve(this.root, inputPath));
+    if (!isInside(abs, this.root)) throw new Error(`Path escapes workspace: ${inputPath}`);
+    this.sessionAllowedGeneratedRoots.add(this.relative(abs));
+  }
+
+  isPathDenied(relPath: string, operation: SandboxOperation = "read"): boolean {
+    return this.inspectPath(relPath, operation).rule !== "allowed";
+  }
+
+  inspectPath(relPath: string, operation: SandboxOperation = "read"): { rule: SandboxRule; suggestedProfile?: SandboxProfile } {
+    const normalized = normalizeRel(relPath);
+    if (isSensitivePath(normalized)) return { rule: "sensitive-path-denied" };
+    const generatedRoot = generatedOutputRoot(normalized);
+    if (!generatedRoot) return { rule: "allowed" };
+    if (operation === "patch") return { rule: "generated-output-patch-denied", suggestedProfile: suggestedProfileForGeneratedRoot(generatedRoot) };
+    if (generatedOutputDirsForProfile(this.profile).includes(generatedRoot)) return { rule: "allowed" };
+    if (this.isSessionAllowedGeneratedPath(normalized)) return { rule: "allowed" };
+    return { rule: "generated-output-read-denied", suggestedProfile: suggestedProfileForGeneratedRoot(generatedRoot) };
+  }
+
+  private assertAllowedPath(relPath: string, operation: SandboxOperation): void {
+    const decision = this.inspectPath(relPath, operation);
+    if (decision.rule === "allowed") return;
+    throw new Error(formatSandboxBlock(decision.rule, relPath, operation, this.profile, decision.suggestedProfile));
+  }
+
+  private isSessionAllowedGeneratedPath(relPath: string): boolean {
+    for (const root of this.sessionAllowedGeneratedRoots) {
+      if (relPath === root || relPath.startsWith(`${root}/`)) return true;
+    }
+    return false;
   }
 
   private resolveWritablePath(inputPath: string): string {
@@ -53,16 +94,53 @@ export class WorkspaceSandbox {
   }
 }
 
-export function isDeniedPath(relPath: string): boolean {
-  const normalized = relPath.replace(/\\/g, "/");
-  if (normalized.split("/").some((segment) => isDeniedEnvSegment(segment))) return true;
-  if (/\.(min\.js|min\.css)$/.test(normalized)) return true;
-  return DEFAULT_IGNORES.filter((pattern) => !pattern.includes("*")).some((pattern) => normalized === pattern || normalized.startsWith(`${pattern}/`));
+export function isDeniedPath(relPath: string, profile: SandboxProfile = "default", operation: SandboxOperation = "read"): boolean {
+  const normalized = normalizeRel(relPath);
+  if (isSensitivePath(normalized)) return true;
+  const root = generatedOutputRoot(normalized);
+  if (!root) return false;
+  if (operation === "patch") return true;
+  return !generatedOutputDirsForProfile(profile).includes(root);
+}
+
+function isSensitivePath(relPath: string): boolean {
+  const segments = relPath.split("/");
+  if (segments.some((segment) => segment === ".git" || segment === "node_modules" || segment === "secrets" || segment === "credentials")) return true;
+  if (segments.some((segment) => isDeniedEnvSegment(segment))) return true;
+  if (/\.(min\.js|min\.css|pem|key)$/i.test(relPath)) return true;
+  return false;
 }
 
 function isDeniedEnvSegment(segment: string): boolean {
   if (segment === ".env.example") return false;
   return segment === ".env" || segment.startsWith(".env.");
+}
+
+function generatedOutputRoot(relPath: string): string | undefined {
+  const segments = relPath.split("/");
+  return GENERATED_OUTPUT_DIRS.find((entry) => segments.includes(entry));
+}
+
+function suggestedProfileForGeneratedRoot(root: string): SandboxProfile {
+  if (["coverage", "reports", "test-results", "junit", ".nyc_output"].includes(root)) return "test";
+  if (["artifacts"].includes(root)) return "package";
+  if (["logs", "temp", ".tmp"].includes(root)) return "debug";
+  return "build";
+}
+
+function formatSandboxBlock(rule: SandboxRule, relPath: string, operation: SandboxOperation, activeProfile: SandboxProfile, suggestedProfile?: SandboxProfile): string {
+  return [
+    `Blocked by sandbox rule: ${rule}`,
+    `Path: ${normalizeRel(relPath)}`,
+    `Operation: ${operation}`,
+    "User approval override: no",
+    `Active profile: ${activeProfile}`,
+    ...(suggestedProfile ? [`Suggested profile: ${suggestedProfile}`] : [])
+  ].join("\n");
+}
+
+function normalizeRel(relPath: string): string {
+  return relPath.replace(/\\/g, "/").replace(/^\/+/, "");
 }
 
 export function looksBinary(absPath: string): boolean {

--- a/tests/applyPatch.test.mjs
+++ b/tests/applyPatch.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { applyPatchTool } from "../dist/tools/definitions/applyPatch.js";
+import { listFilesTool } from "../dist/tools/definitions/listFiles.js";
 import { runShellTool } from "../dist/tools/definitions/runShell.js";
 import { ApprovalPolicy } from "../dist/approval/ApprovalPolicy.js";
 import { ContextManager } from "../dist/context/ContextManager.js";
@@ -56,6 +57,34 @@ test("run_shell allows newly generated output directories for the session", asyn
   }, ctx);
 
   assert.equal(path.basename(ctx.sandbox.assertReadableFile("coverage/report.txt")), "report.txt");
+});
+
+test("run_shell allows newly generated nested output directories for the session", async () => {
+  const root = makeWorkspace();
+  const tool = runShellTool(new ToolSkillRegistry(root));
+  const ctx = makeContext(root);
+
+  await tool.execute({
+    command: "node -e \"const fs=require('fs');fs.mkdirSync('packages/api/dist',{recursive:true});fs.writeFileSync('packages/api/dist/report.txt','ok')\"",
+    reason: "create a nested generated report"
+  }, ctx);
+
+  assert.equal(path.basename(ctx.sandbox.assertReadableFile("packages/api/dist/report.txt")), "report.txt");
+});
+
+test("list_files shows generated outputs allowed for the current session", async () => {
+  const root = makeWorkspace();
+  const runShell = runShellTool(new ToolSkillRegistry(root));
+  const listFiles = listFilesTool(new ToolSkillRegistry(root));
+  const ctx = makeContext(root);
+
+  await runShell.execute({
+    command: "node -e \"const fs=require('fs');fs.mkdirSync('coverage',{recursive:true});fs.writeFileSync('coverage/report.txt','ok')\"",
+    reason: "create a generated test report"
+  }, ctx);
+
+  const result = await listFiles.execute({ glob: "coverage/**" }, ctx);
+  assert.deepEqual(result.files, ["coverage/report.txt"]);
 });
 
 function makeWorkspace() {

--- a/tests/applyPatch.test.mjs
+++ b/tests/applyPatch.test.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { applyPatchTool } from "../dist/tools/definitions/applyPatch.js";
+import { runShellTool } from "../dist/tools/definitions/runShell.js";
 import { ApprovalPolicy } from "../dist/approval/ApprovalPolicy.js";
 import { ContextManager } from "../dist/context/ContextManager.js";
 import { WorkspaceSandbox } from "../dist/workspace/WorkspaceSandbox.js";
@@ -42,6 +43,19 @@ test("apply_patch removes files for delete patches", async () => {
   assert.deepEqual(result.modifiedFiles, []);
   assert.deepEqual(result.deletedFiles, ["delete-me.txt"]);
   assert.equal(fs.existsSync(target), false);
+});
+
+test("run_shell allows newly generated output directories for the session", async () => {
+  const root = makeWorkspace();
+  const tool = runShellTool(new ToolSkillRegistry(root));
+  const ctx = makeContext(root);
+
+  await tool.execute({
+    command: "node -e \"const fs=require('fs');fs.mkdirSync('coverage',{recursive:true});fs.writeFileSync('coverage/report.txt','ok')\"",
+    reason: "create a generated test report"
+  }, ctx);
+
+  assert.equal(path.basename(ctx.sandbox.assertReadableFile("coverage/report.txt")), "report.txt");
 });
 
 function makeWorkspace() {

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -11,7 +11,7 @@ import { ApprovalPolicy, classifyPatchRisk } from "../dist/approval/ApprovalPoli
 import { CORE_SYSTEM_PROMPT } from "../dist/agent/prompts.js";
 import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
-import { parseMaxSteps, parseServerToolOverrides } from "../dist/cli.js";
+import { parseMaxSteps, parseSandboxProfile, parseServerToolOverrides } from "../dist/cli.js";
 
 const root = process.cwd();
 const skillPath = path.join(root, "src", "skills", "builtin", "tree-based-code-navigation.md");
@@ -188,4 +188,11 @@ test("CLI max steps parser accepts only positive integers", () => {
   assert.throws(() => parseMaxSteps("-1"), /--max-steps must be a positive integer/);
   assert.throws(() => parseMaxSteps("1.5"), /--max-steps must be a positive integer/);
   assert.throws(() => parseMaxSteps("abc"), /--max-steps must be a positive integer/);
+});
+
+test("CLI sandbox profile parser accepts known profiles only", () => {
+  assert.equal(parseSandboxProfile(undefined), undefined);
+  assert.equal(parseSandboxProfile("default"), "default");
+  assert.equal(parseSandboxProfile("test"), "test");
+  assert.throws(() => parseSandboxProfile("wide-open"), /--profile must be one of/);
 });

--- a/tests/workspaceSandbox.test.mjs
+++ b/tests/workspaceSandbox.test.mjs
@@ -32,7 +32,7 @@ test("readable symlinks cannot bypass denied workspace paths", (t) => {
   }
 
   const sandbox = new WorkspaceSandbox(root);
-  assert.throws(() => sandbox.assertReadableFile("safe-link.txt"), /Path is denied by sandbox: \.env/);
+  assert.throws(() => sandbox.assertReadableFile("safe-link.txt"), /sensitive-path-denied/);
 });
 
 test(".env.example is readable while real env files stay denied", () => {
@@ -49,12 +49,50 @@ test(".env.example is readable while real env files stay denied", () => {
   assert.equal(isDeniedPath(".env.example"), false);
   assert.equal(isDeniedPath("sub/.env.example"), false);
   assert.equal(isDeniedPath("sub/.env"), true);
+  assert.equal(isDeniedPath("secrets/token.txt"), true);
+  assert.equal(isDeniedPath("certs/private.pem"), true);
   assert.equal(path.basename(sandbox.assertReadableFile(".env.example")), ".env.example");
   assert.equal(path.basename(sandbox.assertReadableFile("sub/.env.example")), ".env.example");
-  assert.throws(() => sandbox.assertReadableFile(".env"), /Path is denied by sandbox: \.env/);
-  assert.throws(() => sandbox.assertReadableFile(".env.local"), /Path is denied by sandbox: \.env\.local/);
-  assert.throws(() => sandbox.assertReadableFile("sub/.env"), /Path is denied by sandbox: sub\/\.env/);
-  assert.throws(() => sandbox.assertReadableFile("sub/.env.local"), /Path is denied by sandbox: sub\/\.env\.local/);
+  assert.throws(() => sandbox.assertReadableFile(".env"), /sensitive-path-denied/);
+  assert.throws(() => sandbox.assertReadableFile(".env.local"), /sensitive-path-denied/);
+  assert.throws(() => sandbox.assertReadableFile("sub/.env"), /sensitive-path-denied/);
+  assert.throws(() => sandbox.assertReadableFile("sub/.env.local"), /sensitive-path-denied/);
+});
+
+test("generated outputs are denied by default with actionable errors", () => {
+  const { root } = makeWorkspace();
+  fs.mkdirSync(path.join(root, "coverage"));
+  fs.writeFileSync(path.join(root, "coverage", "index.html"), "report");
+
+  const sandbox = new WorkspaceSandbox(root);
+  assert.equal(isDeniedPath("coverage/index.html"), true);
+  assert.throws(
+    () => sandbox.assertReadableFile("coverage/index.html"),
+    /Blocked by sandbox rule: generated-output-read-denied[\s\S]*Suggested profile: test/
+  );
+});
+
+test("sandbox profiles allow generated output reads while keeping secrets denied", () => {
+  const { root } = makeWorkspace();
+  fs.mkdirSync(path.join(root, "coverage"));
+  fs.writeFileSync(path.join(root, "coverage", "index.html"), "report");
+  fs.writeFileSync(path.join(root, "coverage", ".env"), "SECRET=value");
+
+  const sandbox = new WorkspaceSandbox(root, "test");
+  assert.equal(isDeniedPath("coverage/index.html", "test"), false);
+  assert.equal(path.basename(sandbox.assertReadableFile("coverage/index.html")), "index.html");
+  assert.throws(() => sandbox.assertReadableFile("coverage/.env"), /sensitive-path-denied/);
+});
+
+test("generated output directories can be allowed for the current session", () => {
+  const { root } = makeWorkspace();
+  fs.mkdirSync(path.join(root, "dist"));
+  fs.writeFileSync(path.join(root, "dist", "summary.txt"), "ok");
+
+  const sandbox = new WorkspaceSandbox(root);
+  assert.throws(() => sandbox.assertReadableFile("dist/summary.txt"), /generated-output-read-denied/);
+  sandbox.allowGeneratedOutputPath("dist");
+  assert.equal(path.basename(sandbox.assertReadableFile("dist/summary.txt")), "summary.txt");
 });
 
 test("writable patch paths reject symlink path components", (t) => {


### PR DESCRIPTION
## Summary

- add `--profile default|build|test|debug|package|docs` and include the active sandbox profile in status output
- split sandbox policy into hard-denied sensitive paths and profile-controlled generated output paths
- allow build/test/debug/package/docs profiles to read common generated outputs while keeping secrets, credentials, keys, `.git`, `node_modules`, minified files, and binary files denied
- mark newly created common generated output directories from approved `run_shell` commands as readable for the current session
- update list/search/code navigation filters to use the active sandbox profile and add actionable sandbox block errors
- document sandbox profiles and add regression tests

Closes #32

## Tests

- `npm run build`
- `npm test`