### PR TITLE
Honor trusted workspaces for local operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ If you deny and choose another approach, Grok Code asks for guidance and returns
 
 Local tools can only read and write inside the workspace root. The sandbox always rejects sensitive paths such as `.git` internals, `node_modules`, `.env` secrets, credentials, private keys, minified generated files, and binary files.
 
-Sandbox profiles allow read access to common generated outputs for task-specific workflows while keeping sensitive paths hard-denied:
+Workspace trust is the user's permission boundary for local workspace operations. Once a directory is trusted through the interactive trust prompt or `/trust`, normal local operations inside that trusted workspace are allowed, including reading and patching generated outputs such as `dist`, `build`, `coverage`, and `reports`. Trust does not bypass hard-denied sensitive paths.
+
+For untrusted workspaces, sandbox profiles allow read access to common generated outputs for task-specific workflows while keeping sensitive paths hard-denied:
 
 - `default`: source-oriented access; generated outputs stay denied.
 - `build`: allows common build outputs such as `build`, `dist`, `out`, `target`, `.next`, and generated source directories.

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -20,7 +20,7 @@ export class Agent {
   readonly skillLoader: SkillLoader;
 
   constructor(private readonly client: OpenAI, readonly config: GrokCodeConfig, originalTask = "") {
-    this.sandbox = new WorkspaceSandbox(config.workspaceRoot, config.sandboxProfile);
+    this.sandbox = new WorkspaceSandbox(config.workspaceRoot, config.sandboxProfile, config.workspaceTrusted);
     this.approval = new ApprovalPolicy(config.approval, originalTask);
     this.toolSkills = new ToolSkillRegistry(config.workspaceRoot);
     this.toolSkills.loadBuiltin(LOCAL_TOOL_NAMES);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { SessionStore } from "./session/SessionStore.js";
 import { colorDiff } from "./ui/diffView.js";
 import { PROJECT_UNDERSTANDING_TASK } from "./agent/projectUnderstandingTask.js";
 import { ensureWorkspaceTrusted } from "./ui/workspaceTrust.js";
+import { WorkspaceTrustStore } from "./workspace/WorkspaceTrustStore.js";
 
 type CliOpts = {
   model?: string;
@@ -57,10 +58,12 @@ export async function main(): Promise<void> {
 
 async function makeAgent(opts: CliOpts, task = "", cwd = process.cwd()): Promise<Agent> {
   const toolOverrides = parseServerToolOverrides(process.argv.slice(2));
+  const workspaceTrusted = Boolean(new WorkspaceTrustStore().getTrustFor(cwd));
   const config = loadConfig(cwd, {
     model: opts.model,
     approval: opts.approval,
     sandboxProfile: parseSandboxProfile(opts.profile),
+    workspaceTrusted,
     toolChoice: opts.toolChoice,
     maxSteps: parseMaxSteps(opts.maxSteps),
     serverTools: toolOverrides.serverTools,
@@ -160,6 +163,7 @@ function localSessionStatus(opts: CliOpts): void {
     model: opts.model,
     approval: opts.approval,
     sandboxProfile: parseSandboxProfile(opts.profile),
+    workspaceTrusted: Boolean(new WorkspaceTrustStore().getTrustFor(process.cwd())),
     toolChoice: opts.toolChoice,
     maxSteps: parseMaxSteps(opts.maxSteps),
     serverTools: toolOverrides.serverTools,

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -16,6 +16,7 @@ export type GrokCodeConfig = {
   enableXSearch: boolean;
   workspaceRoot: string;
   sandboxProfile: SandboxProfile;
+  workspaceTrusted: boolean;
 };
 
 export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfig> = {}): GrokCodeConfig {
@@ -32,6 +33,7 @@ export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfi
     enableXSearch: true,
     workspaceRoot: cwd,
     sandboxProfile: "default",
+    workspaceTrusted: false,
     ...projectConfig,
     ...cleanOverrides
   };

--- a/src/ui/terminal.ts
+++ b/src/ui/terminal.ts
@@ -11,6 +11,7 @@ export function formatSessionStatus(config: GrokCodeConfig): string {
     `model:        ${config.model}`,
     `provider:     xAI`,
     `workspace:    ${config.workspaceRoot}`,
+    `trusted:      ${config.workspaceTrusted ? "yes" : "no"}`,
     `approval:     ${config.approval}`,
     `profile:      ${config.sandboxProfile}`,
     `tool choice:  ${config.toolChoice}`,

--- a/src/workspace/WorkspaceSandbox.ts
+++ b/src/workspace/WorkspaceSandbox.ts
@@ -9,11 +9,13 @@ type SandboxRule = "allowed" | "sensitive-path-denied" | "generated-output-read-
 export class WorkspaceSandbox {
   readonly root: string;
   readonly profile: SandboxProfile;
+  readonly trusted: boolean;
   private readonly sessionAllowedGeneratedRoots = new Set<string>();
 
-  constructor(root: string, profile: SandboxProfile = "default") {
+  constructor(root: string, profile: SandboxProfile = "default", trusted = false) {
     this.root = fs.realpathSync(root);
     this.profile = profile;
+    this.trusted = trusted;
   }
 
   resolvePath(inputPath = "."): string {
@@ -66,6 +68,7 @@ export class WorkspaceSandbox {
     if (isSensitivePath(normalized)) return { rule: "sensitive-path-denied" };
     const generatedRoot = generatedOutputRoot(normalized);
     if (!generatedRoot) return { rule: "allowed" };
+    if (this.trusted) return { rule: "allowed" };
     if (operation === "patch") return { rule: "generated-output-patch-denied", suggestedProfile: suggestedProfileForGeneratedRoot(generatedRoot) };
     if (generatedOutputDirsForProfile(this.profile).includes(generatedRoot)) return { rule: "allowed" };
     if (this.isSessionAllowedGeneratedPath(normalized)) return { rule: "allowed" };
@@ -94,11 +97,12 @@ export class WorkspaceSandbox {
   }
 }
 
-export function isDeniedPath(relPath: string, profile: SandboxProfile = "default", operation: SandboxOperation = "read"): boolean {
+export function isDeniedPath(relPath: string, profile: SandboxProfile = "default", operation: SandboxOperation = "read", trusted = false): boolean {
   const normalized = normalizeRel(relPath);
   if (isSensitivePath(normalized)) return true;
   const root = generatedOutputRoot(normalized);
   if (!root) return false;
+  if (trusted) return false;
   if (operation === "patch") return true;
   return !generatedOutputDirsForProfile(profile).includes(root);
 }

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -149,6 +149,7 @@ test("xAI server-side search tools are enabled by default", () => {
   assert.equal(config.serverTools, true);
   assert.equal(config.enableWebSearch, true);
   assert.equal(config.enableXSearch, true);
+  assert.equal(config.workspaceTrusted, false);
 });
 
 test("undefined CLI overrides do not disable default server-side search tools", () => {

--- a/tests/workspaceSandbox.test.mjs
+++ b/tests/workspaceSandbox.test.mjs
@@ -95,6 +95,19 @@ test("generated output directories can be allowed for the current session", () =
   assert.equal(path.basename(sandbox.assertReadableFile("dist/summary.txt")), "summary.txt");
 });
 
+test("trusted workspaces allow local generated output operations", () => {
+  const { root } = makeWorkspace();
+  fs.mkdirSync(path.join(root, "dist"));
+  fs.writeFileSync(path.join(root, "dist", "summary.txt"), "ok");
+  fs.writeFileSync(path.join(root, "dist", ".env"), "SECRET=value");
+
+  const sandbox = new WorkspaceSandbox(root, "default", true);
+  assert.equal(isDeniedPath("dist/summary.txt", "default", "read", true), false);
+  assert.equal(path.basename(sandbox.assertReadableFile("dist/summary.txt")), "summary.txt");
+  assert.equal(sandbox.assertWritablePatchPath("dist/summary.txt"), path.join(root, "dist", "summary.txt"));
+  assert.throws(() => sandbox.assertReadableFile("dist/.env"), /sensitive-path-denied/);
+});
+
 test("writable patch paths reject symlink path components", (t) => {
   const { root, outside } = makeWorkspace();
   const linkPath = path.join(root, "linked-dir");


### PR DESCRIPTION
## Summary

- Thread remembered workspace trust into the runtime config and sandbox
- Allow trusted workspaces to read and patch generated local outputs without requiring a sandbox profile
- Keep hard-denied sensitive paths blocked even when the workspace is trusted
- Show trusted workspace status in `status` output and document the behavior

## Citation

Follow-up to PR #33 feedback: https://github.com/jason920612/Grok-cli/pull/33#issuecomment-4365495969

> 應該直接允許在信任目錄的本地操作否則信任不信任目錄根本沒有意義

## Tests

- `npm run build`
- `npm test`