### PR TITLE
Fix built-in skill loading and safety guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "bin": {
     "grok-code": "./dist/index.js"
   },
+  "files": [
+    "dist",
+    "src/skills/builtin",
+    "src/tool-skills/builtin"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/index.ts",

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -187,7 +187,7 @@ export function shouldContinueAfterPlanOnlyResponse(text: string, task: string, 
   const lower = text.toLowerCase();
   const taskLower = task.toLowerCase();
   const saysItWillUseTools = /(brief plan|before first tool call|i'?ll now|i will now|proceeding to|run the first tool|call .*tool|use .*tool|工具)/i.test(text);
-  const englishActionTask = /(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|issue|pr)/i.test(taskLower);
+  const englishActionTask = /\b(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|issue|pr)\b/i.test(taskLower);
   const localizedActionTask = ["\u4fee bug", "\u4fee\u6539", "\u4fee\u6b63", "\u5efa\u7acb", "\u65b0\u589e", "\u522a\u9664", "\u6267\u884c", "\u57f7\u884c", "\u6e2c\u8a66", "\u6d4b\u8bd5", "\u5efa\u7f6e", "\u63d0\u4ea4", "\u63a8\u9001", "\u5be9\u6838", "\u5ba1\u6838", "\u958bpr", "\u958b issue"].some((keyword) => taskLower.includes(keyword));
   const claimsNoCapability = /no .*tool available|there is no .*tool|tools limited to/i.test(lower);
   return actionCount === 0 && (englishActionTask || localizedActionTask) && (saysItWillUseTools || claimsNoCapability);

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -182,15 +182,15 @@ function formatActionSummary(actions: ToolActionSummary[]): string {
     .join("\n");
 }
 
-function shouldContinueAfterPlanOnlyResponse(text: string, task: string, actionCount: number): boolean {
+export function shouldContinueAfterPlanOnlyResponse(text: string, task: string, actionCount: number): boolean {
   if (!text.trim()) return false;
   const lower = text.toLowerCase();
   const taskLower = task.toLowerCase();
-  const saysItWillUseTools = /(brief plan|before first tool call|i'?ll now|i will now|proceeding to|run the first tool|call .*tool|use .*tool)/i.test(text);
-  const actionTask = /(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|提交|推送|修改|刪除|创建|建立)/i.test(taskLower);
+  const saysItWillUseTools = /(brief plan|before first tool call|i'?ll now|i will now|proceeding to|run the first tool|call .*tool|use .*tool|工具)/i.test(text);
+  const englishActionTask = /(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|issue|pr)/i.test(taskLower);
+  const localizedActionTask = ["\u4fee bug", "\u4fee\u6539", "\u4fee\u6b63", "\u5efa\u7acb", "\u65b0\u589e", "\u522a\u9664", "\u6267\u884c", "\u57f7\u884c", "\u6e2c\u8a66", "\u6d4b\u8bd5", "\u5efa\u7f6e", "\u63d0\u4ea4", "\u63a8\u9001", "\u5be9\u6838", "\u5ba1\u6838", "\u958bpr", "\u958b issue"].some((keyword) => taskLower.includes(keyword));
   const claimsNoCapability = /no .*tool available|there is no .*tool|tools limited to/i.test(lower);
-  const localizedActionTask = ["提交", "推送", "修改", "修正", "刪除", "创建", "建立"].some((keyword) => taskLower.includes(keyword));
-  return actionCount === 0 && (actionTask || localizedActionTask) && (saysItWillUseTools || claimsNoCapability);
+  return actionCount === 0 && (englishActionTask || localizedActionTask) && (saysItWillUseTools || claimsNoCapability);
 }
 
 function throwIfAborted(signal?: AbortSignal): void {

--- a/src/approval/RiskClassifier.ts
+++ b/src/approval/RiskClassifier.ts
@@ -23,7 +23,7 @@ export function classifyCommand(command: string, background = false): CommandRis
 }
 
 function isWindowsDestructiveDelete(command: string): boolean {
-  return /\bremove-item\b[\s\S]*\s-(recurse|r)\b[\s\S]*\s-(force|f)\b/.test(command)
+  return /\bremove-item\b/.test(command) && /\s-(recurse|r)\b/.test(command) && /\s-(force|f)\b/.test(command)
     || /\bdel(?:ete)?\b[\s\S]*(\/s\b[\s\S]*\/q\b|\/q\b[\s\S]*\/s\b)/.test(command)
     || /\brmdir\b[\s\S]*(\/s\b[\s\S]*\/q\b|\/q\b[\s\S]*\/s\b)/.test(command)
     || /\brd\b[\s\S]*(\/s\b[\s\S]*\/q\b|\/q\b[\s\S]*\/s\b)/.test(command);

--- a/src/approval/RiskClassifier.ts
+++ b/src/approval/RiskClassifier.ts
@@ -10,14 +10,21 @@ export type CommandRisk =
 export function classifyCommand(command: string, background = false): CommandRisk {
   const c = command.trim().toLowerCase();
   if (background) {
-    if (/(deploy|publish|git\s+push|rm\s+-rf|sudo|ssh|scp|curl\s+.*\|\s*sh|wget\s+.*\|\s*sh|\s-g\b|global\s+add)/.test(c)) return "deny";
+    if (/(deploy|publish|git\s+push|rm\s+-rf|sudo|ssh|scp|curl\s+.*\|\s*sh|wget\s+.*\|\s*sh|\s-g\b|global\s+add)/.test(c) || isWindowsDestructiveDelete(c)) return "deny";
     if (/(dev|watch|storybook|preview|serve|vite|next|webpack|nodemon|tsx watch)/.test(c)) return "background";
     return "ask";
   }
   if (/(npm\s+(install|i)\s+-g|pnpm\s+add\s+-g|yarn\s+global\s+add|bun\s+install\s+-g|sudo\s+(pip|npm)|brew\s+install|apt(-get)?\s+install|yum\s+install|dnf\s+install|pacman\s+-s|choco\s+install|winget\s+install|\.zshrc|\.bashrc|\.profile|config\.fish|path\s*=)/.test(c)) return "global_environment_change";
-  if (/(rm\s+-rf|sudo|chmod\s+-r|chown|ssh|scp|curl\s+.*\|\s*sh|wget\s+.*\|\s*sh|git\s+push|npm\s+publish|deploy)/.test(c)) return "deny";
+  if (/(rm\s+-rf|sudo|chmod\s+-r|chown|ssh|scp|curl\s+.*\|\s*sh|wget\s+.*\|\s*sh|git\s+push|npm\s+publish|deploy)/.test(c) || isWindowsDestructiveDelete(c)) return "deny";
   if (/(curl|wget|git\s+clone|npm\s+install|pnpm\s+install|pnpm\s+add|npm\s+install\s+--save-dev)/.test(c)) return "network";
   if (/^(ls|dir|pwd|rg|grep|git\s+status|git\s+diff|npm\s+test|npm\s+run\s+build|pnpm\s+test|pnpm\s+build|pnpm\s+exec|npm\s+exec|npx|poetry\s+run|uv\s+run|bundle\s+exec|cargo\s+test|go\s+test)/.test(c)) return "safe";
   if (/^(python|node)\s+.+\.(py|js|mjs|cjs|ts)$/.test(c) || /^(git\s+checkout|git\s+commit)/.test(c)) return "ask";
   return "ask";
+}
+
+function isWindowsDestructiveDelete(command: string): boolean {
+  return /\bremove-item\b[\s\S]*\s-(recurse|r)\b[\s\S]*\s-(force|f)\b/.test(command)
+    || /\bdel(?:ete)?\b[\s\S]*(\/s\b[\s\S]*\/q\b|\/q\b[\s\S]*\/s\b)/.test(command)
+    || /\brmdir\b[\s\S]*(\/s\b[\s\S]*\/q\b|\/q\b[\s\S]*\/s\b)/.test(command)
+    || /\brd\b[\s\S]*(\/s\b[\s\S]*\/q\b|\/q\b[\s\S]*\/s\b)/.test(command);
 }

--- a/src/packageRoot.ts
+++ b/src/packageRoot.ts
@@ -1,0 +1,13 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export function resolvePackageRoot(moduleUrl: string): string {
+  let current = path.dirname(fileURLToPath(moduleUrl));
+  for (;;) {
+    if (fs.existsSync(path.join(current, "package.json"))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return path.dirname(fileURLToPath(moduleUrl));
+    current = parent;
+  }
+}

--- a/src/skills/SkillLoader.ts
+++ b/src/skills/SkillLoader.ts
@@ -2,12 +2,15 @@ import fs from "node:fs";
 import path from "node:path";
 import type { Skill } from "./Skill.js";
 import { tokenEstimate } from "../context/tokenEstimate.js";
+import { resolvePackageRoot } from "../packageRoot.js";
+
+const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 
 export class SkillLoader {
   constructor(private readonly workspaceRoot: string) {}
 
   loadAll(): Skill[] {
-    const builtins = this.loadDir(path.join(this.workspaceRoot, "src", "skills", "builtin"), true);
+    const builtins = this.loadDir(path.join(PACKAGE_ROOT, "src", "skills", "builtin"), true);
     const project = this.loadProjectSkills();
     return [...builtins, ...project];
   }
@@ -22,7 +25,7 @@ export class SkillLoader {
       || forcedSkillIds.includes(skill.id)
       || skill.triggers.some((trigger) => lower.includes(trigger))
     );
-    if (/(run|test|build|install|lint|dev|server|command)/i.test(task)) {
+    if (/(run|test|build|install|lint|dev|server|command)/i.test(task) || includesAny(task, ["\u57f7\u884c", "\u6e2c\u8a66", "\u6d4b\u8bd5", "\u5efa\u7f6e", "\u5b89\u88dd"])) {
       const env = all.find((skill) => skill.id === "environment-awareness");
       if (env && !selected.includes(env)) selected.push(env);
     }
@@ -74,15 +77,15 @@ function priorityFor(id: string): number {
 }
 
 function triggersFor(id: string): string[] {
-  return {
+  const triggers: Record<string, string[]> = {
     "code-navigation": ["find", "where", "read", "search", "symbol", "file"],
-    "patch-editing": ["edit", "fix", "change", "modify", "implement", "refactor"],
-    debugging: ["debug", "error", "failed", "exception", "stack"],
-    "test-driven-fix": ["test", "failing", "regression"],
-    "shell-usage": ["command", "shell", "run", "build", "lint"],
-    "environment-awareness": ["environment", "install", "setup", "build", "test", "dev"],
-    "git-commit-push": ["commit", "push", "git commit", "git push", "write commit", "提交", "推送"],
-    "project-local-setup": ["install", "setup", "dependency", "tooling"],
+    "patch-editing": ["edit", "fix", "change", "modify", "implement", "refactor", "\u4fee\u6539", "\u4fee\u6b63"],
+    debugging: ["debug", "error", "failed", "exception", "stack", "\u9664\u932f", "\u9519\u8bef"],
+    "test-driven-fix": ["test", "failing", "regression", "\u6e2c\u8a66", "\u6d4b\u8bd5"],
+    "shell-usage": ["command", "shell", "run", "build", "lint", "\u57f7\u884c", "\u6267\u884c", "\u5efa\u7f6e"],
+    "environment-awareness": ["environment", "install", "setup", "build", "test", "dev", "\u74b0\u5883", "\u5b89\u88dd"],
+    "git-commit-push": ["commit", "push", "git commit", "git push", "write commit", "\u63d0\u4ea4", "\u63a8\u9001", "\u9001\u51fa", "\u958bpr", "\u958b pr"],
+    "project-local-setup": ["install", "setup", "dependency", "tooling", "\u5b89\u88dd", "\u8a2d\u5b9a"],
     "project-understanding": ["project-understanding"],
     "tree-based-code-navigation": [
       "codebase",
@@ -101,9 +104,17 @@ function triggersFor(id: string): string[] {
       "fix",
       "change",
       "feature",
-      "review"
+      "review",
+      "\u4fee\u6539",
+      "\u4fee\u6b63",
+      "\u529f\u80fd"
     ]
-  }[id] ?? [id];
+  };
+  return triggers[id] ?? [id];
+}
+
+function includesAny(value: string, needles: string[]): boolean {
+  return needles.some((needle) => value.includes(needle));
 }
 
 function forcedSkills(task: string): string[] {

--- a/src/tool-skills/ToolSkillRegistry.ts
+++ b/src/tool-skills/ToolSkillRegistry.ts
@@ -2,6 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import type { ToolSkill } from "./ToolSkill.js";
 import { tokenEstimate } from "../context/tokenEstimate.js";
+import { resolvePackageRoot } from "../packageRoot.js";
+
+const PACKAGE_ROOT = resolvePackageRoot(import.meta.url);
 
 export class ToolSkillRegistry {
   private skills = new Map<string, ToolSkill>();
@@ -10,7 +13,7 @@ export class ToolSkillRegistry {
 
   loadBuiltin(toolNames: string[]): void {
     for (const toolName of toolNames) {
-      const file = path.join(this.root, "src", "tool-skills", "builtin", `${toolName}.skill.md`);
+      const file = path.join(PACKAGE_ROOT, "src", "tool-skills", "builtin", `${toolName}.skill.md`);
       const full = fs.existsSync(file) ? fs.readFileSync(file, "utf8") : defaultFull(toolName);
       this.skills.set(toolName, makeSkill(toolName, full));
     }

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { SkillLoader } from "../dist/skills/SkillLoader.js";
 import { ContextManager } from "../dist/context/ContextManager.js";
@@ -8,6 +9,8 @@ import { buildModelInput } from "../dist/agent/modelInputBuilder.js";
 import { ToolSkillRegistry } from "../dist/tool-skills/ToolSkillRegistry.js";
 import { LOCAL_TOOL_NAMES, createLocalToolRegistry } from "../dist/tools/definitions/index.js";
 import { ApprovalPolicy, classifyPatchRisk } from "../dist/approval/ApprovalPolicy.js";
+import { classifyCommand } from "../dist/approval/RiskClassifier.js";
+import { shouldContinueAfterPlanOnlyResponse } from "../dist/agent/AgentLoop.js";
 import { CORE_SYSTEM_PROMPT } from "../dist/agent/prompts.js";
 import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
@@ -26,6 +29,23 @@ test("tree-based code navigation skill file exists and loads", () => {
   assert.match(skill.content, /Expand only high-confidence nodes/);
 });
 
+test("built-in skills load when target workspace is not the package checkout", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "grok-external-workspace-"));
+  const loader = new SkillLoader(workspace);
+  const skill = loader.loadAll().find((item) => item.id === "tree-based-code-navigation");
+  assert.ok(skill);
+  assert.match(skill.content, /Search before reading/);
+});
+
+test("built-in tool skills load when target workspace is not the package checkout", () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "grok-external-workspace-"));
+  const toolSkills = new ToolSkillRegistry(workspace);
+  toolSkills.loadBuiltin(["read_file_range"]);
+  const skill = toolSkills.get("read_file_range");
+  assert.match(skill.full, /Read precise file ranges/);
+  assert.doesNotMatch(skill.full, /Use read_file_range carefully with narrow scope/);
+});
+
 test("coding tasks select tree-based code navigation", () => {
   const loader = new SkillLoader(root);
   const selected = loader.select("debug a failing test with a stack trace and modify code");
@@ -34,7 +54,7 @@ test("coding tasks select tree-based code navigation", () => {
 
 test("commit and push tasks select git workflow skill", () => {
   const loader = new SkillLoader(root);
-  const selected = loader.select("幫我寫commit並push");
+  const selected = loader.select("write commit and push");
   assert.ok(selected.some((skill) => skill.id === "git-commit-push"));
 });
 
@@ -94,6 +114,24 @@ test("approval policy supports local and all automation levels", async () => {
 
   const never = new ApprovalPolicy("never");
   assert.equal(await never.approvePatch("workspace patch"), false);
+});
+
+test("Windows destructive delete commands are hard-denied", () => {
+  assert.equal(classifyCommand("Remove-Item -LiteralPath dist -Recurse -Force"), "deny");
+  assert.equal(classifyCommand("del /s /q dist"), "deny");
+  assert.equal(classifyCommand("rmdir /s /q dist"), "deny");
+  assert.equal(classifyCommand("rd /q /s dist"), "deny");
+});
+
+test("plan-only retry detection handles Chinese action tasks", () => {
+  assert.equal(
+    shouldContinueAfterPlanOnlyResponse("\u6211\u6703\u5148\u7528\u5de5\u5177\u6aa2\u67e5\uff0c\u63a5\u8457\u4fee\u6539\u3002", "\u8acb\u4fee bug \u4e26\u57f7\u884c\u6e2c\u8a66", 0),
+    true
+  );
+  assert.equal(
+    shouldContinueAfterPlanOnlyResponse("\u6211\u53ef\u4ee5\u63d0\u4f9b\u4e00\u4e9b\u5efa\u8b70\u3002", "\u8acb\u4fee bug", 1),
+    false
+  );
 });
 
 test("patch approval classifies higher-risk patch metadata", async () => {

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -118,6 +118,8 @@ test("approval policy supports local and all automation levels", async () => {
 
 test("Windows destructive delete commands are hard-denied", () => {
   assert.equal(classifyCommand("Remove-Item -LiteralPath dist -Recurse -Force"), "deny");
+  assert.equal(classifyCommand("Remove-Item -Force -Recurse dist"), "deny");
+  assert.equal(classifyCommand("Remove-Item -r -f dist"), "deny");
   assert.equal(classifyCommand("del /s /q dist"), "deny");
   assert.equal(classifyCommand("rmdir /s /q dist"), "deny");
   assert.equal(classifyCommand("rd /q /s dist"), "deny");
@@ -131,6 +133,14 @@ test("plan-only retry detection handles Chinese action tasks", () => {
   assert.equal(
     shouldContinueAfterPlanOnlyResponse("\u6211\u53ef\u4ee5\u63d0\u4f9b\u4e00\u4e9b\u5efa\u8b70\u3002", "\u8acb\u4fee bug", 1),
     false
+  );
+  assert.equal(
+    shouldContinueAfterPlanOnlyResponse("I will use tools to inspect the project.", "explain the project structure", 0),
+    false
+  );
+  assert.equal(
+    shouldContinueAfterPlanOnlyResponse("I will use tools to inspect the issue.", "open pr for the fix", 0),
+    true
   );
 });
 


### PR DESCRIPTION
## Summary

- resolve built-in general skills and tool skills from the installed package root instead of the active target workspace
- include built-in skill markdown directories in npm package files
- replace localized plan-only retry detection with encoding-safe Unicode escape keywords and export the helper for tests
- hard-deny Windows destructive delete forms in the risk classifier
- add regression tests for external-workspace built-in loading, Chinese plan-only action retry, and Windows destructive deletes

Closes #35
Closes #36
Closes #37

## Tests

- `npm run build`
- `npm test`