### PR TITLE
Improve approval prompt UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Run `grok-code` with no task to enter interactive mode.
 - `/trust`, `/trust-settings`, and `/workspace-trust` view, change, or clear remembered workspace trust settings.
 - `/skills` shows skills loaded for the current interactive baseline separately from skills that are available and loaded only when triggered.
 - `/approval <mode>` changes approval mode during interactive sessions.
+- `/help` shows the focused everyday command set. Compatibility aliases and diagnostic commands still work when typed directly, but are hidden by default to keep the interface quiet.
 
 Useful slash commands:
 
@@ -91,12 +92,7 @@ Useful slash commands:
 /diff
 /approval <mode>
 /learn-project
-/context
-/compact
 /skills
-/tools
-/env
-/bg
 /exit
 ```
 
@@ -247,11 +243,11 @@ Modes:
 
 Global environment changes are never auto-approved except in `auto-all`. Hard-denied commands, such as destructive deletes, shell install pipes, deploys, publishes, and git pushes, remain blocked in every mode.
 
-When approval is required, the prompt is a menu:
+When approval is required, Grok Code shows a focused decision prompt with the operation, request, reason, risk, current policy, scope, and the remembered-rule key when one is available. Patch approvals also summarize the affected files and line counts. The menu options are:
 
-- allow this time
-- allow and remember similar requests for this session
-- no, use another approach
+- yes, allow this time
+- yes, and remember similar requests for this session
+- no, tell the model what to do instead
 
 If you deny and choose another approach, Grok Code asks for guidance and returns that guidance to the model.
 

--- a/src/approval/ApprovalPolicy.ts
+++ b/src/approval/ApprovalPolicy.ts
@@ -50,7 +50,12 @@ export class ApprovalPolicy {
       return { approved: false, risk, message: "Approval policy is never." };
     }
     if (risk === "safe") return { approved: true, risk };
-    const decision = await promptApproval(command, reason, risk);
+    const decision = await promptApproval(command, reason, risk, {
+      operation: options.background ? "run background command" : "run shell command",
+      policy: this.currentMode,
+      scope: options.background ? "workspace background process" : "workspace shell",
+      rememberKey: key
+    });
     if (decision.approved && decision.rememberSimilar) {
       this.rememberedApprovals.add(key);
     }
@@ -67,7 +72,12 @@ export class ApprovalPolicy {
     if (risk === "safe") return true;
     if (this.currentMode === "auto-safe") return false;
     if (this.currentMode === "auto-local" || this.currentMode === "auto-all") return true;
-    const decision = await promptApproval(formatPatchApprovalCommand(metadata!), reason, "ask");
+    const decision = await promptApproval(formatPatchApprovalCommand(metadata!), reason, "ask", {
+      operation: "apply workspace patch",
+      policy: this.currentMode,
+      scope: "workspace files",
+      files: metadata!.files
+    });
     return decision.approved;
   }
 }

--- a/src/approval/promptApproval.ts
+++ b/src/approval/promptApproval.ts
@@ -2,20 +2,25 @@ import { input, select } from "@inquirer/prompts";
 import chalk from "chalk";
 import type { CommandRisk } from "./RiskClassifier.js";
 
+export type ApprovalPromptDetails = {
+  operation?: string;
+  policy?: string;
+  scope?: string;
+  rememberKey?: string;
+  files?: Array<{
+    path: string;
+    operation: "create" | "modify" | "delete";
+    additions: number;
+    deletions: number;
+  }>;
+};
+
 export type ApprovalPromptDecision =
   | { approved: true; rememberSimilar: boolean }
   | { approved: false; rememberSimilar: false; guidance?: string };
 
-export async function promptApproval(command: string, reason: string, risk: CommandRisk): Promise<ApprovalPromptDecision> {
-  console.log(chalk.yellow("Approval required"));
-  console.log(`Command: ${command}`);
-  console.log(`Reason: ${reason}`);
-  console.log(`Risk: ${risk}`);
-  if (risk === "global_environment_change") {
-    console.log("This may modify global tools, shell profiles, PATH, package managers, or system-level runtime state.");
-    console.log("Project-local setup was not sufficient or was not selected by the model.");
-    console.log("Rollback depends on the package manager or file changed.");
-  }
+export async function promptApproval(command: string, reason: string, risk: CommandRisk, details: ApprovalPromptDetails = {}): Promise<ApprovalPromptDecision> {
+  console.log(formatApprovalPrompt(command, reason, risk, details));
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     return {
       approved: false,
@@ -24,20 +29,20 @@ export async function promptApproval(command: string, reason: string, risk: Comm
     };
   }
   const choice = await select({
-    message: "Choose how to handle this request",
+    message: "Approve this operation?",
     choices: [
       {
-        name: "Allow this time",
+        name: "Yes, allow this time",
         value: "allow_once",
-        description: "Run this exact request once."
+        description: "Approve only this exact operation."
       },
       {
-        name: "Allow and remember similar requests",
+        name: "Yes, and remember similar",
         value: "allow_similar",
-        description: "Run this request and auto-approve similar requests in this session."
+        description: "Approve now and auto-approve the displayed operation type in this session."
       },
       {
-        name: "No, use another approach",
+        name: "No, tell the model what to do instead",
         value: "deny_with_guidance",
         description: "Deny this request and tell the model what to try instead."
       }
@@ -50,4 +55,55 @@ export async function promptApproval(command: string, reason: string, risk: Comm
     default: "Use a safer project-local approach that does not require this approval."
   });
   return { approved: false, rememberSimilar: false, guidance };
+}
+
+export function formatApprovalPrompt(command: string, reason: string, risk: CommandRisk, details: ApprovalPromptDetails = {}): string {
+  const lines = [
+    chalk.yellow.bold("Approval required"),
+    `${chalk.bold("Operation:")} ${details.operation ?? riskLabel(risk)}`,
+    `${chalk.bold("Request:")} ${command}`,
+    `${chalk.bold("Reason:")} ${reason}`,
+    `${chalk.bold("Risk:")} ${riskLabel(risk)}`
+  ];
+
+  if (details.scope) lines.push(`${chalk.bold("Scope:")} ${details.scope}`);
+  if (details.policy) lines.push(`${chalk.bold("Policy:")} ${details.policy}`);
+  if (details.rememberKey) lines.push(`${chalk.bold("Remember rule:")} ${details.rememberKey}`);
+
+  const impact = riskImpact(risk);
+  if (impact) lines.push(`${chalk.bold("Impact:")} ${impact}`);
+
+  if (details.files?.length) {
+    lines.push(chalk.bold("Files:"));
+    for (const file of details.files.slice(0, 8)) {
+      lines.push(`  ${file.operation.padEnd(6)} ${file.path} (+${file.additions}/-${file.deletions})`);
+    }
+    if (details.files.length > 8) lines.push(`  ... ${details.files.length - 8} more`);
+  }
+
+  return lines.join("\n");
+}
+
+function riskLabel(risk: CommandRisk): string {
+  return {
+    safe: "safe local operation",
+    ask: "approval-required operation",
+    deny: "blocked operation",
+    global_environment_change: "global environment change",
+    destructive: "destructive operation",
+    network: "network or dependency operation",
+    background: "background process"
+  }[risk];
+}
+
+function riskImpact(risk: CommandRisk): string | undefined {
+  return {
+    safe: undefined,
+    ask: "This is outside the default safe set and needs your decision before it runs.",
+    deny: "This operation is blocked by policy.",
+    destructive: "This may delete or overwrite data and is blocked by policy.",
+    network: "This may download code or modify local dependencies.",
+    background: "This starts a long-running process that may continue until stopped.",
+    global_environment_change: "This may modify global tools, shell profiles, PATH, package managers, or system-level runtime state."
+  }[risk];
 }

--- a/src/ui/repl.ts
+++ b/src/ui/repl.ts
@@ -147,12 +147,12 @@ function setApproval(agent: Agent, mode: ApprovalMode): string {
   return `Approval mode set to ${mode}: ${approvalDescription(mode)}`;
 }
 
-function approvalDescription(mode: ApprovalMode): string {
+export function approvalDescription(mode: ApprovalMode): string {
   return {
     "on-request": "Default. Auto-allow workspace file edits and safe local commands; ask for riskier commands.",
     "auto-local": "Auto-allow operations scoped to this workspace/local environment; still asks for global environment changes.",
     "auto-safe": "Auto-allow only safe commands and local patch edits; ask for network/install/unknown commands.",
-    "auto-all": "Auto-allow every model-requested operation, including global or destructive commands.",
+    "auto-all": "Auto-allow model-requested operations except commands that are hard-denied by the safety policy.",
     never: "Deny approval-required operations."
   }[mode];
 }

--- a/src/ui/repl.ts
+++ b/src/ui/repl.ts
@@ -5,7 +5,7 @@ import { formatContext } from "./formatters.js";
 import { PROJECT_UNDERSTANDING_TASK } from "../agent/projectUnderstandingTask.js";
 import { colorDiff } from "./diffView.js";
 import { readInteractiveLine, runWithEscInterrupt } from "./interactiveInput.js";
-import { SLASH_COMMANDS } from "./slashCommands.js";
+import { visibleSlashCommands } from "./slashCommands.js";
 import type { ApprovalMode } from "../config/loadConfig.js";
 import { formatSessionStatus } from "./terminal.js";
 import { chooseWorkspace, formatWorkspaceTrustStatus, manageWorkspaceTrust } from "./workspaceTrust.js";
@@ -40,7 +40,7 @@ async function handleSlash(command: string, agent: Agent, options: ReplOptions):
   const [name, ...rest] = command.split(/\s+/);
   switch (name) {
     case "/help":
-      console.log(SLASH_COMMANDS.map((cmd) => `${cmd.usage.padEnd(24)} ${cmd.description}`).join("\n"));
+      console.log(visibleSlashCommands().map((cmd) => `${cmd.usage.padEnd(24)} ${cmd.description}`).join("\n"));
       break;
     case "/status":
       console.log([formatSessionStatus(agent.config), formatWorkspaceTrustStatus(agent.config.workspaceRoot)].join("\n"));

--- a/src/ui/slashCommands.ts
+++ b/src/ui/slashCommands.ts
@@ -2,32 +2,37 @@ export type SlashCommand = {
   name: string;
   usage: string;
   description: string;
+  hidden?: boolean;
 };
 
 export const SLASH_COMMANDS: SlashCommand[] = [
   { name: "/help", usage: "/help", description: "Show available commands." },
   { name: "/status", usage: "/status", description: "Show session status." },
   { name: "/cd", usage: "/cd", description: "Change workspace directory from a menu." },
-  { name: "/workspace", usage: "/workspace", description: "Change workspace directory from a menu." },
-  { name: "/change-dir", usage: "/change-dir", description: "Change workspace directory from a menu." },
+  { name: "/workspace", usage: "/workspace", description: "Change workspace directory from a menu.", hidden: true },
+  { name: "/change-dir", usage: "/change-dir", description: "Change workspace directory from a menu.", hidden: true },
   { name: "/trust", usage: "/trust", description: "View or change workspace trust settings." },
-  { name: "/trust-settings", usage: "/trust-settings", description: "View or change workspace trust settings." },
-  { name: "/workspace-trust", usage: "/workspace-trust", description: "View or change workspace trust settings." },
+  { name: "/trust-settings", usage: "/trust-settings", description: "View or change workspace trust settings.", hidden: true },
+  { name: "/workspace-trust", usage: "/workspace-trust", description: "View or change workspace trust settings.", hidden: true },
   { name: "/git-status", usage: "/git-status", description: "Show git status." },
   { name: "/diff", usage: "/diff", description: "Show git-style diff for current changes." },
   { name: "/approval", usage: "/approval", description: "Choose approval mode from a menu." },
-  { name: "/model", usage: "/model <model>", description: "Show model change guidance." },
   { name: "/clear", usage: "/clear", description: "Compact and clear stale context." },
-  { name: "/resume", usage: "/resume", description: "Show resume guidance." },
-  { name: "/context", usage: "/context", description: "Show context items." },
-  { name: "/compact", usage: "/compact", description: "Compact context now." },
+  { name: "/model", usage: "/model <model>", description: "Show model change guidance.", hidden: true },
+  { name: "/resume", usage: "/resume", description: "Show resume guidance.", hidden: true },
+  { name: "/context", usage: "/context", description: "Show context items.", hidden: true },
+  { name: "/compact", usage: "/compact", description: "Compact context now.", hidden: true },
   { name: "/learn-project", usage: "/learn-project", description: "Inspect project and update GROK.md." },
   { name: "/skills", usage: "/skills", description: "List loaded skills." },
-  { name: "/tools", usage: "/tools", description: "List available tools." },
-  { name: "/env", usage: "/env", description: "Inspect environment." },
-  { name: "/bg", usage: "/bg", description: "List background commands." },
-  { name: "/bg-stop", usage: "/bg-stop <id>", description: "Stop one background command." },
-  { name: "/bg-stop-all", usage: "/bg-stop-all", description: "Stop all background commands." },
-  { name: "/drop", usage: "/drop <context-item-id>", description: "Drop one context item." },
+  { name: "/tools", usage: "/tools", description: "List available tools.", hidden: true },
+  { name: "/env", usage: "/env", description: "Inspect environment.", hidden: true },
+  { name: "/bg", usage: "/bg", description: "List background commands.", hidden: true },
+  { name: "/bg-stop", usage: "/bg-stop <id>", description: "Stop one background command.", hidden: true },
+  { name: "/bg-stop-all", usage: "/bg-stop-all", description: "Stop all background commands.", hidden: true },
+  { name: "/drop", usage: "/drop <context-item-id>", description: "Drop one context item.", hidden: true },
   { name: "/exit", usage: "/exit", description: "Exit interactive mode." }
 ];
+
+export function visibleSlashCommands(): SlashCommand[] {
+  return SLASH_COMMANDS.filter((command) => !command.hidden);
+}

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -10,11 +10,13 @@ import { ToolSkillRegistry } from "../dist/tool-skills/ToolSkillRegistry.js";
 import { LOCAL_TOOL_NAMES, createLocalToolRegistry } from "../dist/tools/definitions/index.js";
 import { ApprovalPolicy, classifyPatchRisk } from "../dist/approval/ApprovalPolicy.js";
 import { classifyCommand } from "../dist/approval/RiskClassifier.js";
+import { formatApprovalPrompt } from "../dist/approval/promptApproval.js";
 import { shouldContinueAfterPlanOnlyResponse } from "../dist/agent/AgentLoop.js";
 import { CORE_SYSTEM_PROMPT } from "../dist/agent/prompts.js";
 import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
 import { parseMaxSteps, parseSandboxProfile, parseServerToolOverrides } from "../dist/cli.js";
+import { SLASH_COMMANDS, visibleSlashCommands } from "../dist/ui/slashCommands.js";
 
 const root = process.cwd();
 const skillPath = path.join(root, "src", "skills", "builtin", "tree-based-code-navigation.md");
@@ -161,6 +163,35 @@ test("patch approval classifies higher-risk patch metadata", async () => {
 
   const autoLocal = new ApprovalPolicy("auto-local");
   assert.equal(await autoLocal.approvePatch("package patch", packagePatch), true);
+});
+
+test("approval prompt summarizes decision details without invoking skills", () => {
+  const prompt = formatApprovalPrompt("npm install", "install local dependencies", "network", {
+    operation: "run shell command",
+    policy: "on-request",
+    scope: "workspace shell",
+    rememberKey: "foreground:network:npm install",
+    files: [{ path: "package.json", operation: "modify", additions: 1, deletions: 1 }]
+  });
+
+  assert.match(prompt, /Approval required/);
+  assert.match(prompt, /Operation:.*run shell command/);
+  assert.match(prompt, /Policy:.*on-request/);
+  assert.match(prompt, /Remember rule:.*foreground:network:npm install/);
+  assert.match(prompt, /modify package\.json \(\+1\/-1\)/);
+});
+
+test("help shows a focused slash command set while aliases remain registered", () => {
+  const visible = visibleSlashCommands().map((command) => command.name);
+  const all = SLASH_COMMANDS.map((command) => command.name);
+
+  assert.ok(visible.includes("/help"));
+  assert.ok(visible.includes("/approval"));
+  assert.ok(visible.includes("/skills"));
+  assert.ok(all.includes("/workspace"));
+  assert.equal(visible.includes("/workspace"), false);
+  assert.equal(visible.includes("/tools"), false);
+  assert.equal(visible.includes("/env"), false);
 });
 
 test("system prompt requires plans and final action summaries", () => {

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -16,6 +16,7 @@ import { CORE_SYSTEM_PROMPT } from "../dist/agent/prompts.js";
 import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
 import { parseMaxSteps, parseSandboxProfile, parseServerToolOverrides } from "../dist/cli.js";
+import { approvalDescription } from "../dist/ui/repl.js";
 import { SLASH_COMMANDS, visibleSlashCommands } from "../dist/ui/slashCommands.js";
 
 const root = process.cwd();
@@ -116,6 +117,12 @@ test("approval policy supports local and all automation levels", async () => {
 
   const never = new ApprovalPolicy("never");
   assert.equal(await never.approvePatch("workspace patch"), false);
+});
+
+test("auto-all approval description preserves hard-deny semantics", () => {
+  const description = approvalDescription("auto-all");
+  assert.match(description, /hard-denied/i);
+  assert.doesNotMatch(description, /destructive commands/i);
 });
 
 test("Windows destructive delete commands are hard-denied", () => {


### PR DESCRIPTION
## Summary
- Adds a focused approval prompt formatter with operation, request, reason, risk, policy, scope, remember-rule, and patch file summaries.
- Routes command and patch approvals through the enriched prompt without changing skill loading or execution behavior.
- Hides compatibility aliases and lower-value diagnostic slash commands from default `/help` while keeping them registered for direct use.
- Updates README approval and slash command documentation.

Closes #39.

## Tests
- `npm test`