### PR TITLE
Add framed interactive TUI layout

### DIFF
--- a/src/ui/interactiveInput.ts
+++ b/src/ui/interactiveInput.ts
@@ -1,9 +1,19 @@
 import readline from "node:readline";
 import chalk from "chalk";
 import { input } from "@inquirer/prompts";
-import { SLASH_COMMANDS } from "./slashCommands.js";
+import { visibleSlashCommands } from "./slashCommands.js";
+import type { SlashCommand } from "./slashCommands.js";
 
-export async function readInteractiveLine(prompt = "grok-code>"): Promise<string> {
+export type TranscriptEntry = {
+  role: "user" | "assistant" | "system";
+  content: string;
+};
+
+export type InteractiveLineOptions = {
+  transcript?: TranscriptEntry[];
+};
+
+export async function readInteractiveLine(prompt = "grok-code>", options: InteractiveLineOptions = {}): Promise<string> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     return input({ message: prompt });
   }
@@ -18,10 +28,10 @@ export async function readInteractiveLine(prompt = "grok-code>"): Promise<string
     let selected = 0;
 
     const cleanup = (value: string) => {
-      clearPromptAndMenu();
+      clearLayout();
       process.stdin.off("keypress", onKeypress);
+      process.stdout.off("resize", render);
       process.stdin.setRawMode(wasRaw);
-      process.stdout.write(`${chalk.green(prompt)} ${value}\n`);
       resolve(value);
     };
 
@@ -29,31 +39,41 @@ export async function readInteractiveLine(prompt = "grok-code>"): Promise<string
       if (!buffer.startsWith("/")) return [];
       const [commandPart] = buffer.split(/\s+/, 1);
       const needle = commandPart.toLowerCase();
-      return SLASH_COMMANDS.filter((cmd) => cmd.name.startsWith(needle)).slice(0, 10);
+      return visibleSlashCommands().filter((cmd) => cmd.name.startsWith(needle)).slice(0, 8);
     };
 
-    const clearPromptAndMenu = () => {
-      readline.cursorTo(process.stdout, 0);
-      readline.clearLine(process.stdout, 0);
+    const clearLayout = () => {
+      readline.cursorTo(process.stdout, 0, 0);
       readline.clearScreenDown(process.stdout);
     };
 
+    const moveCursorToInput = () => {
+      const rows = process.stdout.rows ?? 24;
+      const cols = process.stdout.columns ?? 80;
+      const suggestionLines = matches().length > 0 ? matches().length + 1 : 0;
+      const transcriptHeight = Math.max(4, rows - suggestionLines - 5);
+      const inputRow = Math.min(rows - 1, transcriptHeight + 2);
+      readline.cursorTo(process.stdout, Math.min(`${prompt} ${buffer}`.length + 2, Math.max(2, cols - 2)), inputRow);
+    };
+
     const render = () => {
-      clearPromptAndMenu();
-      process.stdout.write(`${chalk.green(prompt)} ${buffer}`);
+      clearLayout();
       const list = matches();
       if (list.length > 0) {
         selected = Math.min(selected, list.length - 1);
-        process.stdout.write("\n");
-        for (let i = 0; i < list.length; i += 1) {
-          const cmd = list[i]!;
-          const prefix = i === selected ? chalk.cyan(">") : " ";
-          const name = i === selected ? chalk.cyan(cmd.usage) : cmd.usage;
-          process.stdout.write(`${prefix} ${name} ${chalk.dim(cmd.description)}\n`);
-        }
-        readline.moveCursor(process.stdout, 0, -(list.length + 1));
-        readline.cursorTo(process.stdout, `${prompt} ${buffer}`.length);
       }
+      process.stdout.write(
+        buildInteractiveLayout({
+          transcript: options.transcript ?? [],
+          input: buffer,
+          prompt,
+          suggestions: list,
+          selectedSuggestion: selected,
+          columns: process.stdout.columns ?? 80,
+          rows: process.stdout.rows ?? 24
+        })
+      );
+      moveCursorToInput();
     };
 
     const acceptSelectedCommand = () => {
@@ -98,8 +118,80 @@ export async function readInteractiveLine(prompt = "grok-code>"): Promise<string
     };
 
     process.stdin.on("keypress", onKeypress);
+    process.stdout.on("resize", render);
     render();
   });
+}
+
+export function buildInteractiveLayout({
+  transcript,
+  input,
+  prompt,
+  suggestions,
+  selectedSuggestion,
+  columns,
+  rows
+}: {
+  transcript: TranscriptEntry[];
+  input: string;
+  prompt: string;
+  suggestions: SlashCommand[];
+  selectedSuggestion: number;
+  columns: number;
+  rows: number;
+}): string {
+  const width = Math.max(32, columns);
+  const suggestionLines = suggestions.length > 0 ? suggestions.length + 1 : 0;
+  const transcriptHeight = Math.max(4, rows - suggestionLines - 5);
+  const contentWidth = width - 2;
+  const outputLines = transcript.flatMap((entry) => wrapLine(`${roleLabel(entry.role)}: ${entry.content}`, contentWidth - 2));
+  const visibleOutput = outputLines.slice(-Math.max(1, transcriptHeight - 2));
+  const paddedOutput = [...visibleOutput];
+  while (paddedOutput.length < transcriptHeight - 2) paddedOutput.unshift("");
+
+  const lines = [
+    `┌${"─".repeat(width - 2)}┐`,
+    ...paddedOutput.map((line) => `│ ${padOrTrim(line, contentWidth - 2)} │`),
+    `└${"─".repeat(width - 2)}┘`,
+    "",
+    `╭${"─".repeat(width - 2)}╮`,
+    `│ ${padOrTrim(`${prompt} ${input}`, contentWidth - 2)} │`,
+    `╰${"─".repeat(width - 2)}╯`
+  ];
+
+  if (suggestions.length > 0) {
+    lines.push("Commands:");
+    suggestions.forEach((command, index) => {
+      const marker = index === selectedSuggestion ? ">" : " ";
+      const usage = command.usage.padEnd(16);
+      lines.push(padOrTrim(`  ${marker} ${usage} ${command.description}`, width));
+    });
+  }
+
+  return `${lines.slice(0, rows).join("\n")}`;
+}
+
+function roleLabel(role: TranscriptEntry["role"]): string {
+  return {
+    user: "User",
+    assistant: "Assistant",
+    system: "System"
+  }[role];
+}
+
+function wrapLine(text: string, width: number): string[] {
+  if (width <= 0) return [""];
+  const source = text.replace(/\r?\n/g, " ");
+  const lines: string[] = [];
+  for (let index = 0; index < source.length; index += width) {
+    lines.push(source.slice(index, index + width));
+  }
+  return lines.length > 0 ? lines : [""];
+}
+
+function padOrTrim(text: string, width: number): string {
+  if (text.length > width) return text.slice(0, Math.max(0, width - 1)) + "…";
+  return text.padEnd(width);
 }
 
 export async function runWithEscInterrupt<T>(work: (signal: AbortSignal) => Promise<T>): Promise<T> {

--- a/src/ui/repl.ts
+++ b/src/ui/repl.ts
@@ -4,7 +4,7 @@ import type { Agent } from "../agent/Agent.js";
 import { formatContext } from "./formatters.js";
 import { PROJECT_UNDERSTANDING_TASK } from "../agent/projectUnderstandingTask.js";
 import { colorDiff } from "./diffView.js";
-import { readInteractiveLine, runWithEscInterrupt } from "./interactiveInput.js";
+import { readInteractiveLine, runWithEscInterrupt, type TranscriptEntry } from "./interactiveInput.js";
 import { visibleSlashCommands } from "./slashCommands.js";
 import type { ApprovalMode } from "../config/loadConfig.js";
 import { formatSessionStatus } from "./terminal.js";
@@ -16,109 +16,123 @@ type ReplOptions = {
 
 export async function startRepl(initialAgent: Agent, options: ReplOptions = {}): Promise<Agent> {
   let agent = initialAgent;
-  console.log(chalk.dim("Type /help for commands, /exit to quit."));
+  const transcript: TranscriptEntry[] = [{ role: "system", content: "Type /help for commands, /exit to quit." }];
   for (;;) {
-    const line = await readInteractiveLine("grok-code>");
+    const line = await readInteractiveLine("grok-code>", { transcript });
     const text = line.trim();
     if (!text) continue;
     if (text === "/exit") break;
+    remember(transcript, "user", text);
     if (text.startsWith("/")) {
-      const nextAgent = await handleSlash(text, agent, options);
+      const nextAgent = await handleSlash(text, agent, options, (content) => remember(transcript, "system", content));
       if (nextAgent) agent = nextAgent;
       continue;
     }
     try {
-      console.log(await runWithEscInterrupt((signal) => agent.run(text, false, signal)));
+      const response = await runWithEscInterrupt((signal) => agent.run(text, false, signal));
+      remember(transcript, "assistant", String(response));
+      console.log(response);
     } catch (error) {
-      console.log(chalk.yellow(error instanceof Error ? error.message : String(error)));
+      const message = error instanceof Error ? error.message : String(error);
+      remember(transcript, "system", message);
+      console.log(chalk.yellow(message));
     }
   }
   return agent;
 }
 
-async function handleSlash(command: string, agent: Agent, options: ReplOptions): Promise<Agent | void> {
+async function handleSlash(command: string, agent: Agent, options: ReplOptions, emit: (content: string) => void): Promise<Agent | void> {
   const [name, ...rest] = command.split(/\s+/);
+  const output = (content: string) => {
+    emit(content);
+    console.log(content);
+  };
   switch (name) {
     case "/help":
-      console.log(visibleSlashCommands().map((cmd) => `${cmd.usage.padEnd(24)} ${cmd.description}`).join("\n"));
+      output(visibleSlashCommands().map((cmd) => `${cmd.usage.padEnd(24)} ${cmd.description}`).join("\n"));
       break;
     case "/status":
-      console.log([formatSessionStatus(agent.config), formatWorkspaceTrustStatus(agent.config.workspaceRoot)].join("\n"));
+      output([formatSessionStatus(agent.config), formatWorkspaceTrustStatus(agent.config.workspaceRoot)].join("\n"));
       break;
     case "/cd":
     case "/workspace":
     case "/change-dir": {
       if (!options.switchWorkspace) {
-        console.log("Workspace switching is unavailable in this session.");
+        output("Workspace switching is unavailable in this session.");
         break;
       }
       const workspace = await chooseWorkspace(agent.config.workspaceRoot);
       if (!workspace) {
-        console.log("Workspace unchanged.");
+        output("Workspace unchanged.");
         break;
       }
       await agent.background.stopAll("workspace switch cleanup");
       const nextAgent = await options.switchWorkspace(workspace);
-      console.log(`Workspace switched to ${nextAgent.config.workspaceRoot}`);
+      output(`Workspace switched to ${nextAgent.config.workspaceRoot}`);
       return nextAgent;
     }
     case "/trust":
     case "/trust-settings":
     case "/workspace-trust":
-      console.log(await manageWorkspaceTrust(agent.config.workspaceRoot));
+      output(await manageWorkspaceTrust(agent.config.workspaceRoot));
       break;
     case "/git-status":
-      console.log(JSON.stringify(await agent.tools.execute("git_status", {}, agent.toolContext()), null, 2));
+      output(JSON.stringify(await agent.tools.execute("git_status", {}, agent.toolContext()), null, 2));
       break;
     case "/diff":
-      console.log(formatDiffResult(await agent.tools.execute("git_diff", {}, agent.toolContext())));
+      output(formatDiffResult(await agent.tools.execute("git_diff", {}, agent.toolContext())));
       break;
     case "/approval":
-      console.log(await chooseApproval(agent, rest[0]));
+      output(await chooseApproval(agent, rest[0]));
       break;
     case "/context":
-      console.log(formatContext(agent.context.list()));
+      output(formatContext(agent.context.list()));
       break;
     case "/compact":
-      console.log(agent.context.compactContext("interactive session").content);
+      output(agent.context.compactContext("interactive session").content);
       break;
     case "/learn-project":
-      console.log(await runWithEscInterrupt((signal) => agent.run(PROJECT_UNDERSTANDING_TASK, false, signal)));
+      output(await runWithEscInterrupt((signal) => agent.run(PROJECT_UNDERSTANDING_TASK, false, signal)));
       break;
     case "/skills":
-      console.log(formatSkills(agent));
+      output(formatSkills(agent));
       break;
     case "/tools":
-      console.log(agent.toolSkills.toolIndex());
+      output(agent.toolSkills.toolIndex());
       break;
     case "/env":
-      console.log(JSON.stringify(await agent.tools.execute("inspect_environment", { includeVersions: true }, agent.toolContext()), null, 2));
+      output(JSON.stringify(await agent.tools.execute("inspect_environment", { includeVersions: true }, agent.toolContext()), null, 2));
       break;
     case "/bg":
-      console.log(JSON.stringify(agent.background.list(), null, 2));
+      output(JSON.stringify(agent.background.list(), null, 2));
       break;
     case "/bg-stop":
-      console.log(JSON.stringify(await agent.tools.execute("stop_background_command", { id: rest[0], reason: "user slash command" }, agent.toolContext()), null, 2));
+      output(JSON.stringify(await agent.tools.execute("stop_background_command", { id: rest[0], reason: "user slash command" }, agent.toolContext()), null, 2));
       break;
     case "/bg-stop-all":
-      console.log(JSON.stringify(await agent.tools.execute("stop_all_background_commands", { reason: "user slash command" }, agent.toolContext()), null, 2));
+      output(JSON.stringify(await agent.tools.execute("stop_all_background_commands", { reason: "user slash command" }, agent.toolContext()), null, 2));
       break;
     case "/drop":
-      console.log(agent.context.drop(rest[0] ?? "") ? "dropped" : "not dropped");
+      output(agent.context.drop(rest[0] ?? "") ? "dropped" : "not dropped");
       break;
     case "/clear":
       agent.context.compactContext("cleared interactive context");
-      console.log("context compacted");
+      output("context compacted");
       break;
     case "/resume":
-      console.log("Use `grok-code resume [session-id]` from the shell.");
+      output("Use `grok-code resume [session-id]` from the shell.");
       break;
     case "/model":
-      console.log("Model changes apply to new CLI invocations in this MVP.");
+      output("Model changes apply to new CLI invocations in this MVP.");
       break;
     default:
-      console.log(`Unknown command: ${name}`);
+      output(`Unknown command: ${name}`);
   }
+}
+
+function remember(transcript: TranscriptEntry[], role: TranscriptEntry["role"], content: string): void {
+  transcript.push({ role, content });
+  if (transcript.length > 40) transcript.splice(0, transcript.length - 40);
 }
 
 async function chooseApproval(agent: Agent, requestedMode?: string): Promise<string> {

--- a/tests/skillLoader.test.mjs
+++ b/tests/skillLoader.test.mjs
@@ -17,6 +17,7 @@ import { loadConfig } from "../dist/config/loadConfig.js";
 import { parseResponse } from "../dist/api/responseParser.js";
 import { parseMaxSteps, parseSandboxProfile, parseServerToolOverrides } from "../dist/cli.js";
 import { approvalDescription } from "../dist/ui/repl.js";
+import { buildInteractiveLayout } from "../dist/ui/interactiveInput.js";
 import { SLASH_COMMANDS, visibleSlashCommands } from "../dist/ui/slashCommands.js";
 
 const root = process.cwd();
@@ -199,6 +200,29 @@ test("help shows a focused slash command set while aliases remain registered", (
   assert.equal(visible.includes("/workspace"), false);
   assert.equal(visible.includes("/tools"), false);
   assert.equal(visible.includes("/env"), false);
+});
+
+test("interactive layout renders transcript pane, framed input, and command suggestions", () => {
+  const commands = visibleSlashCommands().filter((command) => ["/help", "/exit"].includes(command.name));
+  const layout = buildInteractiveLayout({
+    transcript: [
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" }
+    ],
+    input: "/",
+    prompt: "grok-code>",
+    suggestions: commands,
+    selectedSuggestion: 0,
+    columns: 72,
+    rows: 16
+  });
+
+  assert.match(layout, /┌/);
+  assert.match(layout, /Assistant: hi there/);
+  assert.match(layout, /╭/);
+  assert.match(layout, /grok-code> \//);
+  assert.match(layout, /Commands:/);
+  assert.match(layout, /> \/help/);
 });
 
 test("system prompt requires plans and final action summaries", () => {


### PR DESCRIPTION
## Summary
- Render interactive TTY input inside a framed bottom input box with command suggestions below it.
- Keep a bounded REPL transcript and show user, assistant, and system messages in a framed output pane above the input area.
- Re-render the layout on terminal resize while preserving the non-TTY inquirer fallback.
- Add regression coverage for the framed transcript/input/suggestion layout.

Closes #41.

## Tests
- `npm test`

Note: `npm test` fails inside the local sandbox with Node test runner `spawn EPERM`, then passes when rerun outside the sandbox.