### PR TITLE
feat: stateless/hybrid agent loop mode with external situation memory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto eol=lf
+*.ts text eol=lf
+*.md text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.mjs text eol=lf

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,35 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -13,6 +13,8 @@ import { finalAnswerGate } from "./finalAnswerGate.js";
 import { SituationMemory } from "./SituationMemory.js";
 import { runVerifier, auditIntermediateClaims, type VerifierResult } from "./Verifier.js";
 
+type FunctionCallOutput = { type: "function_call_output"; call_id: string; output: string };
+
 type ToolActionSummary = {
   step: number;
   name: string;
@@ -37,7 +39,8 @@ export class AgentLoop {
     const isHybrid = this.config.conversationMode === "hybrid";
 
     let previousResponseId: string | undefined;
-    let hybridForceStateless = false;
+    // hybridIsStateless becomes true after a hybrid reset and stays true for the remainder
+    let hybridIsStateless = false;
     let finalText = "";
     const usedToolNames = new Set<string>();
     const toolActionSummaries: ToolActionSummary[] = [];
@@ -57,20 +60,20 @@ export class AgentLoop {
       throwIfAborted(signal);
       this.context.nextStep(task);
 
-      // hybrid: reset stateful chain after thresholds
-      if (isHybrid && previousResponseId && !hybridForceStateless) {
+      // hybrid: reset stateful chain after thresholds — once reset, stays stateless
+      if (isHybrid && !hybridIsStateless && previousResponseId) {
         const shouldReset =
           step > this.config.hybridResetAfterSteps ||
           situationMemory.totalFailures() >= this.config.hybridResetAfterFailures;
         if (shouldReset) {
           previousResponseId = undefined;
-          hybridForceStateless = true;
+          hybridIsStateless = true;
           pendingInput = this.buildStatelessPrompt(task, situationMemory);
-          console.log(`[hybrid] Context reset at step ${step} — rebuilding from situation memory.`);
+          console.log(`[hybrid] Context reset at step ${step} — switching to stateless mode.`);
         }
       }
 
-      const useStateless = isStateless || hybridForceStateless;
+      const useStateless = isStateless || hybridIsStateless;
 
       const spinner = ora(`Grok thinking (step ${step})`).start();
       let response: any;
@@ -90,7 +93,6 @@ export class AgentLoop {
       throwIfAborted(signal);
       const parsed = parseResponse(response);
       previousResponseId = parsed.id || previousResponseId;
-      hybridForceStateless = false;
 
       // watchdog: empty response
       if (!parsed.finalText && parsed.functionCalls.length === 0) {
@@ -110,8 +112,27 @@ export class AgentLoop {
       }
       emptyResponseRetries = 0;
 
-      // narration guard: intent described but no tool call
+      // narration guard: intent without tool call
       if (parsed.functionCalls.length === 0) {
+        // block finalization if unresolved pending verifications exist (always, no reprompt-count bypass)
+        const unresolved = situationMemory.getUnresolvedVerifications();
+        if (this.config.enableVerifier && unresolved.length > 0) {
+          if (verifierReprompts < this.config.maxVerifierReprompts) {
+            verifierReprompts += 1;
+            console.log(`[verifier] Blocking finalization: ${unresolved.length} unresolved pending verification(s).`);
+            pendingInput = this.buildCorrectionInput(
+              task,
+              buildPendingVerificationBlock(unresolved),
+              useStateless ? situationMemory : undefined
+            );
+            step += 1;
+            continue;
+          }
+          // budget exhausted — fail closed, never accept with unresolved items
+          finalText = `[agent stopped: ${unresolved.length} verification requirement(s) unresolved after max reprompts. Claims: ${unresolved.map((p) => p.claim).join("; ")}]`;
+          break;
+        }
+
         if (planOnlyReprompts < 2 && shouldContinueAfterPlanOnlyResponse(parsed.finalText, task, toolActionSummaries.length)) {
           planOnlyReprompts += 1;
           console.log(parsed.finalText);
@@ -125,46 +146,25 @@ export class AgentLoop {
           continue;
         }
 
-        // block finalization if unresolved pending verifications exist
-        const unresolved = situationMemory.getUnresolvedVerifications();
-        if (this.config.enableVerifier && unresolved.length > 0 && verifierReprompts < 2) {
-          verifierReprompts += 1;
-          console.log(`[verifier] Blocking finalization: ${unresolved.length} unresolved pending verification(s).`);
-          pendingInput = this.buildCorrectionInput(
-            task,
-            buildPendingVerificationBlock(unresolved),
-            useStateless ? situationMemory : undefined
-          );
-          step += 1;
-          continue;
-        }
-
         // candidate final answer — run verifier if enabled
         if (this.config.enableVerifier && parsed.finalText) {
-          const accepted = await this.runVerifierLoop(
-            task,
-            situationMemory,
-            parsed.finalText,
-            verifierReprompts,
-            verifierCrashCount,
-            useStateless,
-            step,
-            signal
+          const outcome = await this.runVerifierLoop(
+            task, situationMemory, parsed.finalText, verifierReprompts, verifierCrashCount, step, signal
           );
-          if (!accepted.pass) {
-            if (accepted.crashed) {
-              verifierCrashCount += 1;
-              if (verifierCrashCount >= 2) {
-                finalText = `[agent stopped: verifier failed to produce a verdict after ${verifierCrashCount} attempts. Refusing to accept unverified final answer. Last error: ${accepted.reason}]`;
-                break;
-              }
+          if (!outcome.pass) {
+            if ("stop" in outcome && outcome.stop) {
+              finalText = outcome.stopMessage;
+              break;
             }
-            if (accepted.correction) {
-              verifierReprompts += 1;
-              pendingInput = this.buildCorrectionInput(task, accepted.correction, useStateless ? situationMemory : undefined);
-              step += 1;
-              continue;
-            }
+            verifierReprompts += 1;
+            if ("crashed" in outcome && outcome.crashed) verifierCrashCount += 1;
+            pendingInput = this.buildCorrectionInput(
+              task,
+              "correction" in outcome ? outcome.correction : "[verifier error]",
+              useStateless ? situationMemory : undefined
+            );
+            step += 1;
+            continue;
           }
         }
 
@@ -173,14 +173,15 @@ export class AgentLoop {
       }
 
       planOnlyReprompts = 0;
+
+      // intermediate claim audit: scan planning text alongside tool calls
       if (parsed.finalText) {
         console.log(parsed.finalText);
-        // intermediate audit: check planning text for unsupported current-state claims
         if (this.config.enableVerifier) {
           await this.auditIntermediateText(situationMemory, parsed.finalText, step, signal);
         }
       }
-      console.log(formatToolBatch(step, parsed.functionCalls.map((call) => call.name)));
+      console.log(formatToolBatch(step, parsed.functionCalls.map((c) => c.name)));
 
       // blind-retry guard
       const blocked = this.findBlockedCall(parsed.functionCalls, situationMemory);
@@ -191,33 +192,25 @@ export class AgentLoop {
         console.log(`[guard] Blocking blind retry of ${blocked.name} (failed ${record.attempts}x).`);
         pendingInput = this.buildCorrectionInput(
           task,
-          `BLIND RETRY BLOCKED:\nTool: ${record.tool}\nError: ${record.error}\nAttempts: ${record.attempts}\nConstraint: Do not retry the exact same action unchanged. Choose a different approach.`,
+          `BLIND RETRY BLOCKED:\nTool: ${record.tool}\nError: ${record.error}\nAttempts: ${record.attempts}\nConstraint: Do not retry unchanged. Choose a different approach.`,
           useStateless ? situationMemory : undefined
         );
         step += 1;
         continue;
       }
 
-      await this.executeToolBatch(
-        parsed.functionCalls,
-        step,
-        usedToolNames,
-        toolActionSummaries,
-        hasModifiedFiles,
-        situationMemory,
-        signal
+      const outputs = await this.executeToolBatch(
+        parsed.functionCalls, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal
       );
 
-      // in stateless/hybrid: rebuild from situation memory — do NOT pass raw
-      // function_call_output protocol items into a fresh call without previous_response_id
-      if (useStateless || isStateless || isHybrid) {
+      if (useStateless) {
+        // stateless or hybrid-after-reset: rebuild from situation memory
+        // do NOT pass stale function_call_output protocol items without previous_response_id
         pendingInput = this.buildStatelessPrompt(task, situationMemory);
       } else {
-        pendingInput = [];
+        // stateful: send function_call_output items back to Responses API
+        pendingInput = outputs;
       }
-
-      // if verifier is enabled, check for pending verifications in the snapshot
-      // (pending verifications are already embedded in the situation snapshot for the executor to see)
 
       step += 1;
     }
@@ -245,57 +238,71 @@ export class AgentLoop {
   ): Promise<void> {
     const verifierModel = this.config.verifierModel || this.config.model;
     const result = await auditIntermediateClaims(this.client, verifierModel, memory.getEvidence(), planningText, signal);
-    if (!result.ok) return; // lenient on intermediate audit failure — don't block tool execution
+    if (!result.ok) {
+      // Record failure — do not silently drop. Final verifier will be stricter.
+      memory.recordAuditFailure();
+      console.log(`[intermediate audit] Audit failed: ${result.reason}. Recorded for stricter final verification.`);
+      return;
+    }
     for (const assumption of result.unsupported_assumptions) {
       memory.addPendingVerification(assumption.claim, assumption.required_verification, step);
-      console.log(`[intermediate audit] Unsupported claim queued for verification: ${assumption.claim.slice(0, 100)}`);
+      console.log(`[intermediate audit] Unsupported claim queued: ${assumption.claim.slice(0, 100)}`);
     }
   }
 
+  /** Runs the verifier. Never returns pass:true if reprompt budget is exhausted — always fail closed. */
   private async runVerifierLoop(
     task: string,
     memory: SituationMemory,
     executorClaim: string,
     reprompts: number,
     crashCount: number,
-    useStateless: boolean,
     step: number,
     signal?: AbortSignal
-  ): Promise<{ pass: boolean; correction?: string; crashed?: boolean; reason?: string }> {
-    if (reprompts >= 2) return { pass: true }; // max verifier rounds reached, accept
+  ): Promise<{ pass: true } | { pass: false; correction: string; crashed?: boolean; stop?: false } | { pass: false; stop: true; stopMessage: string }> {
+    // budget exhausted — fail closed, never accept unverified answer
+    if (reprompts >= this.config.maxVerifierReprompts) {
+      return {
+        pass: false,
+        stop: true,
+        stopMessage: `[agent stopped: max verifier reprompts (${this.config.maxVerifierReprompts}) reached without satisfying verification requirements. Refusing to accept unverified final answer.]`
+      };
+    }
 
     const verifierModel = this.config.verifierModel || this.config.model;
     const result = await runVerifier(
-      this.client,
-      verifierModel,
-      task,
-      memory.getEvidence(),
-      memory.getUnresolvedVerifications(),
-      executorClaim,
-      signal
+      this.client, verifierModel, task,
+      memory.getEvidence(), memory.getUnresolvedVerifications(),
+      executorClaim, memory.hasAuditFailures(), signal
     );
 
     if (!result.ok) {
       console.log(`[verifier] ${result.reason}`);
-      return { pass: false, crashed: true, reason: result.reason };
+      if (crashCount + 1 >= 2) {
+        return {
+          pass: false,
+          stop: true,
+          stopMessage: `[agent stopped: verifier failed ${crashCount + 1} times. Refusing unverified answer. Last error: ${result.reason}]`
+        };
+      }
+      return { pass: false, crashed: true, correction: `[verifier unavailable] ${result.reason}\nPlease provide additional tool evidence before submitting a final answer.` };
     }
 
     const vr = result.result;
     console.log(`[verifier] verdict=${vr.verdict} confidence=${vr.confidence}`);
 
-    if (vr.verdict === "pass") {
-      if (vr.resolved_claims?.length) memory.resolvePendingVerifications(vr.resolved_claims);
+    if (vr.resolved_claims?.length) memory.resolvePendingVerifications(vr.resolved_claims);
+
+    if (vr.verdict === "pass" && memory.getUnresolvedVerifications().length === 0) {
       return { pass: true };
     }
 
-    // add unsupported assumptions to pending verification queue
+    // add new unsupported assumptions to pending queue
     for (const assumption of vr.unsupported_assumptions) {
       memory.addPendingVerification(assumption.claim, assumption.required_verification, step);
     }
-    if (vr.resolved_claims?.length) memory.resolvePendingVerifications(vr.resolved_claims);
 
-    const correction = buildVerifierCorrection(vr);
-    return { pass: false, correction };
+    return { pass: false, correction: buildVerifierCorrection(vr) };
   }
 
   private buildInput(task: string, memory?: SituationMemory): string {
@@ -346,23 +353,25 @@ export class AgentLoop {
     hasModifiedFiles: { value: boolean },
     situationMemory: SituationMemory,
     signal?: AbortSignal
-  ): Promise<void> {
+  ): Promise<FunctionCallOutput[]> {
+    const outputs: FunctionCallOutput[] = [];
     for (let index = 0; index < functionCalls.length;) {
       const call = functionCalls[index];
       if (this.tools.isReadOnly(call.name)) {
-        const readOnlyCalls: typeof functionCalls = [];
+        const batch: typeof functionCalls = [];
         while (index < functionCalls.length && this.tools.isReadOnly(functionCalls[index].name)) {
-          readOnlyCalls.push(functionCalls[index]);
-          index += 1;
+          batch.push(functionCalls[index++]);
         }
-        await Promise.all(readOnlyCalls.map((item) =>
+        const results = await Promise.all(batch.map((item) =>
           this.executeOneToolCall(item, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal)
         ));
+        outputs.push(...results);
         continue;
       }
-      await this.executeOneToolCall(call, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal);
+      outputs.push(await this.executeOneToolCall(call, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal));
       index += 1;
     }
+    return outputs;
   }
 
   private async executeOneToolCall(
@@ -373,7 +382,7 @@ export class AgentLoop {
     hasModifiedFiles: { value: boolean },
     situationMemory: SituationMemory,
     signal?: AbortSignal
-  ): Promise<void> {
+  ): Promise<FunctionCallOutput> {
     throwIfAborted(signal);
     usedToolNames.add(call.name);
     let args: unknown;
@@ -383,14 +392,14 @@ export class AgentLoop {
       const msg = error instanceof Error ? error.message : String(error);
       situationMemory.recordFailure(call.name, {}, `JSON parse error: ${msg}`, step);
       toolActionSummaries.push({ step, name: call.name, ok: false, summary: `JSON parse error: ${msg}` });
-      return;
+      return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify({ ok: false, error: { code: "json_parse_error", message: msg } }) };
     }
 
     const result = await this.tools.execute(call.name, args, this.toolCtx);
     throwIfAborted(signal);
     if (call.name === "apply_patch" && result.ok) hasModifiedFiles.value = true;
 
-    // rawOutput is the actual tool result — NOT a model-generated summary
+    // rawOutput is the literal tool result — NOT a model-generated summary
     const rawOutput = result.ok
       ? JSON.stringify(result.data).slice(0, 800)
       : `ERROR: ${result.error.message}`;
@@ -409,18 +418,19 @@ export class AgentLoop {
       priority: 45,
       expiresAfterSteps: 2
     });
+    return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
   }
 }
 
 function buildPendingVerificationBlock(unresolved: Array<{ claim: string; requiredAction: string }>): string {
   const lines = [
-    "FINALIZATION BLOCKED: The following claims were identified as unsupported and must be verified with tool calls before a final answer can be accepted:"
+    "FINALIZATION BLOCKED: These claims are unsupported and must be verified with tool evidence:"
   ];
   for (const pv of unresolved) {
     lines.push(`  Claim: ${pv.claim}`);
     lines.push(`  Required action: ${pv.requiredAction}`);
   }
-  lines.push("\nCompliance language ('I verified', 'I checked') is NOT evidence. Perform the required tool calls.");
+  lines.push("\nCompliance language ('I verified', 'I checked') is NOT evidence. Use the required tools.");
   return lines.join("\n");
 }
 
@@ -430,11 +440,11 @@ function buildVerifierCorrection(vr: VerifierResult): string {
     `Reason: ${vr.reason}`
   ];
   if (vr.unsupported_assumptions.length > 0) {
-    lines.push("\nUnsupported assumptions — you must verify these with tool calls:");
+    lines.push("\nUnsupported assumptions — verify with tool calls:");
     for (const a of vr.unsupported_assumptions) {
       lines.push(`  Claim: ${a.claim}`);
       lines.push(`  Why unsupported: ${a.why_unsupported}`);
-      lines.push(`  Required verification: ${a.required_verification}`);
+      lines.push(`  Required: ${a.required_verification}`);
     }
   }
   if (vr.missing_evidence.length > 0) {
@@ -445,7 +455,7 @@ function buildVerifierCorrection(vr: VerifierResult): string {
     lines.push("\nRequired next actions:");
     for (const a of vr.required_next_actions) lines.push(`  - ${a}`);
   }
-  lines.push("\nCompliance language ('I verified', 'I checked') is NOT evidence. Perform the required tool calls.");
+  lines.push("\nCompliance language is NOT evidence. Perform the required tool calls.");
   return lines.join("\n");
 }
 
@@ -454,9 +464,7 @@ function formatToolBatch(step: number, toolNames: string[]): string {
 }
 
 function formatActionSummary(actions: ToolActionSummary[]): string {
-  return actions
-    .map((a) => `- step ${a.step}: ${a.name} ${a.ok ? "ok" : "failed"} - ${a.summary}`)
-    .join("\n");
+  return actions.map((a) => `- step ${a.step}: ${a.name} ${a.ok ? "ok" : "failed"} - ${a.summary}`).join("\n");
 }
 
 export function shouldContinueAfterPlanOnlyResponse(text: string, task: string, actionCount: number): boolean {
@@ -464,7 +472,7 @@ export function shouldContinueAfterPlanOnlyResponse(text: string, task: string, 
   const taskLower = task.toLowerCase();
   const saysItWillUseTools = /(brief plan|before first tool call|i'?ll now|i will now|proceeding to|run the first tool|call .*tool|use .*tool|工具)/i.test(text);
   const englishActionTask = /\b(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|issue|pr)\b/i.test(taskLower);
-  const localizedActionTask = ["修 bug", "修改", "修正", "建立", "新增", "刪除", "執行", "执行", "測試", "测试", "建置", "提交", "推送", "審核", "審核", "開pr", "開 issue"].some((k) => taskLower.includes(k));
+  const localizedActionTask = ["修 bug", "修改", "修正", "建立", "新增", "刪除", "執行", "执行", "測試", "测试", "建置", "提交", "推送", "審核", "開pr", "開 issue"].some((k) => taskLower.includes(k));
   const claimsNoCapability = /no .*tool available|there is no .*tool|tools limited to/i.test(text.toLowerCase());
   return actionCount === 0 && (englishActionTask || localizedActionTask) && (saysItWillUseTools || claimsNoCapability);
 }

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -11,7 +11,7 @@ import type { ToolSkillRegistry } from "../tool-skills/ToolSkillRegistry.js";
 import { buildModelInput } from "./modelInputBuilder.js";
 import { finalAnswerGate } from "./finalAnswerGate.js";
 import { SituationMemory } from "./SituationMemory.js";
-import { runVerifier } from "./Verifier.js";
+import { runVerifier, type VerifierResult } from "./Verifier.js";
 
 type ToolActionSummary = {
   step: number;
@@ -37,7 +37,6 @@ export class AgentLoop {
     const isHybrid = this.config.conversationMode === "hybrid";
 
     let previousResponseId: string | undefined;
-    // tracks whether the next hybrid call should be a fresh stateless call (after a reset)
     let hybridForceStateless = false;
     let finalText = "";
     const usedToolNames = new Set<string>();
@@ -45,6 +44,7 @@ export class AgentLoop {
     let planOnlyReprompts = 0;
     let emptyResponseRetries = 0;
     let verifierReprompts = 0;
+    let verifierCrashCount = 0;
     const hasModifiedFiles = { value: false };
     const situationMemory = new SituationMemory();
 
@@ -57,7 +57,7 @@ export class AgentLoop {
       throwIfAborted(signal);
       this.context.nextStep(task);
 
-      // hybrid: reset stateful context after thresholds
+      // hybrid: reset stateful chain after thresholds
       if (isHybrid && previousResponseId && !hybridForceStateless) {
         const shouldReset =
           step > this.config.hybridResetAfterSteps ||
@@ -92,14 +92,14 @@ export class AgentLoop {
       previousResponseId = parsed.id || previousResponseId;
       hybridForceStateless = false;
 
-      // watchdog: empty response with no tool calls and no text
+      // watchdog: empty response
       if (!parsed.finalText && parsed.functionCalls.length === 0) {
         if (emptyResponseRetries < 1) {
           emptyResponseRetries += 1;
           console.log("[watchdog] Empty response detected. Nudging model to continue.");
           pendingInput = this.buildCorrectionInput(
             task,
-            "Your previous response was empty. Emit exactly one tool call or a final answer. Do not respond with only whitespace.",
+            "Your previous response was empty. Emit exactly one tool call or a final answer.",
             useStateless ? situationMemory : undefined
           );
           step += 1;
@@ -110,15 +110,15 @@ export class AgentLoop {
       }
       emptyResponseRetries = 0;
 
-      // narration guard: model described intent but did not call a tool
+      // narration guard: intent described but no tool call
       if (parsed.functionCalls.length === 0) {
         if (planOnlyReprompts < 2 && shouldContinueAfterPlanOnlyResponse(parsed.finalText, task, toolActionSummaries.length)) {
           planOnlyReprompts += 1;
           console.log(parsed.finalText);
-          console.log("Grok provided a plan without tool calls; requesting actual tool use.");
+          console.log("Grok described intent without acting. Requesting tool call.");
           pendingInput = this.buildCorrectionInput(
             task,
-            "Invalid response: you described an intention but did not call a tool. Return exactly one tool call or a final answer. Describing intent is not the same as acting.",
+            "Invalid response: you described an intention but did not call a tool. Return exactly one tool call or a final answer. Describing intent is not evidence.",
             useStateless ? situationMemory : undefined
           );
           step += 1;
@@ -126,15 +126,31 @@ export class AgentLoop {
         }
 
         // candidate final answer — run verifier if enabled
-        if (this.config.enableVerifier && verifierReprompts < 2 && parsed.finalText) {
-          const verifierResult = await this.verify(task, situationMemory, parsed.finalText, signal);
-          if (verifierResult && verifierResult.verdict !== "pass") {
-            verifierReprompts += 1;
-            const correction = buildVerifierCorrection(verifierResult);
-            console.log(`[verifier] verdict=${verifierResult.verdict} confidence=${verifierResult.confidence}`);
-            pendingInput = this.buildCorrectionInput(task, correction, useStateless ? situationMemory : undefined);
-            step += 1;
-            continue;
+        if (this.config.enableVerifier && parsed.finalText) {
+          const accepted = await this.runVerifierLoop(
+            task,
+            situationMemory,
+            parsed.finalText,
+            verifierReprompts,
+            verifierCrashCount,
+            useStateless,
+            step,
+            signal
+          );
+          if (!accepted.pass) {
+            if (accepted.crashed) {
+              verifierCrashCount += 1;
+              if (verifierCrashCount >= 2) {
+                finalText = `[agent stopped: verifier failed to produce a verdict after ${verifierCrashCount} attempts. Refusing to accept unverified final answer. Last error: ${accepted.reason}]`;
+                break;
+              }
+            }
+            if (accepted.correction) {
+              verifierReprompts += 1;
+              pendingInput = this.buildCorrectionInput(task, accepted.correction, useStateless ? situationMemory : undefined);
+              step += 1;
+              continue;
+            }
           }
         }
 
@@ -146,16 +162,16 @@ export class AgentLoop {
       if (parsed.finalText) console.log(parsed.finalText);
       console.log(formatToolBatch(step, parsed.functionCalls.map((call) => call.name)));
 
-      // blind-retry guard: block repeated failed tool+args before executing
+      // blind-retry guard
       const blocked = this.findBlockedCall(parsed.functionCalls, situationMemory);
       if (blocked) {
         let args: unknown;
         try { args = JSON.parse(blocked.arguments || "{}"); } catch { args = {}; }
         const record = situationMemory.hasRecentlyFailed(blocked.name, args)!;
-        console.log(`[guard] Blocking blind retry of ${blocked.name} (failed ${record.attempts}x). Injecting failure context.`);
+        console.log(`[guard] Blocking blind retry of ${blocked.name} (failed ${record.attempts}x).`);
         pendingInput = this.buildCorrectionInput(
           task,
-          `BLIND RETRY BLOCKED:\nTool: ${record.tool}\nError: ${record.error}\nAttempts: ${record.attempts}\nConstraint: Do not retry the exact same action unchanged. Choose a different approach: narrow the scope, inspect logs, or change strategy.`,
+          `BLIND RETRY BLOCKED:\nTool: ${record.tool}\nError: ${record.error}\nAttempts: ${record.attempts}\nConstraint: Do not retry the exact same action unchanged. Choose a different approach.`,
           useStateless ? situationMemory : undefined
         );
         step += 1;
@@ -172,15 +188,16 @@ export class AgentLoop {
         signal
       );
 
-      // in stateless/hybrid: rebuild fresh prompt from updated situation memory
-      // do NOT pass raw function_call_output protocol items without previous_response_id context
+      // in stateless/hybrid: rebuild from situation memory — do NOT pass raw
+      // function_call_output protocol items into a fresh call without previous_response_id
       if (useStateless || isStateless || isHybrid) {
         pendingInput = this.buildStatelessPrompt(task, situationMemory);
       } else {
-        // stateful: xAI API tracks conversation via previous_response_id
-        // just send an empty continuation signal — the API replays context
         pendingInput = [];
       }
+
+      // if verifier is enabled, check for pending verifications in the snapshot
+      // (pending verifications are already embedded in the situation snapshot for the executor to see)
 
       step += 1;
     }
@@ -198,6 +215,52 @@ export class AgentLoop {
       : "";
     const suffix = `${actionSection}${diffSection}\n\n[Final checks]\nBackground: ${gate.backgroundStatus}\nDiff checked: ${gate.diffChecked ? "yes" : "not needed"}`;
     return finalText ? `${finalText}${suffix}` : `Stopped after max steps without a final model message.${suffix}`;
+  }
+
+  private async runVerifierLoop(
+    task: string,
+    memory: SituationMemory,
+    executorClaim: string,
+    reprompts: number,
+    crashCount: number,
+    useStateless: boolean,
+    step: number,
+    signal?: AbortSignal
+  ): Promise<{ pass: boolean; correction?: string; crashed?: boolean; reason?: string }> {
+    if (reprompts >= 2) return { pass: true }; // max verifier rounds reached, accept
+
+    const verifierModel = this.config.verifierModel || this.config.model;
+    const result = await runVerifier(
+      this.client,
+      verifierModel,
+      task,
+      memory.getEvidence(),
+      memory.getUnresolvedVerifications(),
+      executorClaim,
+      signal
+    );
+
+    if (!result.ok) {
+      console.log(`[verifier] ${result.reason}`);
+      return { pass: false, crashed: true, reason: result.reason };
+    }
+
+    const vr = result.result;
+    console.log(`[verifier] verdict=${vr.verdict} confidence=${vr.confidence}`);
+
+    if (vr.verdict === "pass") {
+      if (vr.resolved_claims?.length) memory.resolvePendingVerifications(vr.resolved_claims);
+      return { pass: true };
+    }
+
+    // add unsupported assumptions to pending verification queue
+    for (const assumption of vr.unsupported_assumptions) {
+      memory.addPendingVerification(assumption.claim, assumption.required_verification, step);
+    }
+    if (vr.resolved_claims?.length) memory.resolvePendingVerifications(vr.resolved_claims);
+
+    const correction = buildVerifierCorrection(vr);
+    return { pass: false, correction };
   }
 
   private buildInput(task: string, memory?: SituationMemory): string {
@@ -238,14 +301,6 @@ export class AgentLoop {
       try { args = JSON.parse(call.arguments || "{}"); } catch { return false; }
       return memory.hasRecentlyFailed(call.name, args) !== undefined;
     });
-  }
-
-  private async verify(task: string, memory: SituationMemory, executorClaim: string, signal?: AbortSignal) {
-    try {
-      return await runVerifier(this.client, this.config.model, task, memory.getEvidence(), executorClaim, signal);
-    } catch {
-      return null;
-    }
   }
 
   private async executeToolBatch(
@@ -295,21 +350,23 @@ export class AgentLoop {
       toolActionSummaries.push({ step, name: call.name, ok: false, summary: `JSON parse error: ${msg}` });
       return;
     }
+
     const result = await this.tools.execute(call.name, args, this.toolCtx);
     throwIfAborted(signal);
     if (call.name === "apply_patch" && result.ok) hasModifiedFiles.value = true;
 
-    const summary = summarizeToolResult(result);
-    toolActionSummaries.push({ step, name: call.name, ok: result.ok, summary });
-
-    const outputExcerpt = result.ok
-      ? (result.summary ?? JSON.stringify(result.data).slice(0, 600))
+    // rawOutput is the actual tool result — NOT a model-generated summary
+    const rawOutput = result.ok
+      ? JSON.stringify(result.data).slice(0, 800)
       : `ERROR: ${result.error.message}`;
 
-    situationMemory.recordEvidence(call.name, args, outputExcerpt, result.ok, step);
-    if (!result.ok) {
-      situationMemory.recordFailure(call.name, args, result.error.message, step);
-    }
+    const summary = result.ok
+      ? (result.summary ?? JSON.stringify(result.data).slice(0, 240))
+      : result.error.message;
+
+    toolActionSummaries.push({ step, name: call.name, ok: result.ok, summary });
+    situationMemory.recordEvidence(call.name, args, rawOutput, result.ok, step);
+    if (!result.ok) situationMemory.recordFailure(call.name, args, result.error.message, step);
 
     this.context.add({
       type: "shell_output",
@@ -320,45 +377,38 @@ export class AgentLoop {
   }
 }
 
-function buildVerifierCorrection(result: Awaited<ReturnType<typeof runVerifier>>): string {
-  if (!result) return "";
+function buildVerifierCorrection(vr: VerifierResult): string {
   const lines = [
-    `VERIFIER AUDIT — verdict: ${result.verdict} (confidence: ${result.confidence})`,
-    `Reason: ${result.reason}`
+    `VERIFIER AUDIT — verdict: ${vr.verdict} (confidence: ${vr.confidence})`,
+    `Reason: ${vr.reason}`
   ];
-  if (result.unsupported_assumptions.length > 0) {
-    lines.push("\nUnsupported assumptions detected:");
-    for (const a of result.unsupported_assumptions) {
-      lines.push(`- Claim: ${a.claim}`);
+  if (vr.unsupported_assumptions.length > 0) {
+    lines.push("\nUnsupported assumptions — you must verify these with tool calls:");
+    for (const a of vr.unsupported_assumptions) {
+      lines.push(`  Claim: ${a.claim}`);
       lines.push(`  Why unsupported: ${a.why_unsupported}`);
       lines.push(`  Required verification: ${a.required_verification}`);
     }
   }
-  if (result.missing_evidence.length > 0) {
+  if (vr.missing_evidence.length > 0) {
     lines.push("\nMissing evidence:");
-    for (const e of result.missing_evidence) lines.push(`- ${e}`);
+    for (const e of vr.missing_evidence) lines.push(`  - ${e}`);
   }
-  if (result.required_next_actions.length > 0) {
+  if (vr.required_next_actions.length > 0) {
     lines.push("\nRequired next actions:");
-    for (const a of result.required_next_actions) lines.push(`- ${a}`);
+    for (const a of vr.required_next_actions) lines.push(`  - ${a}`);
   }
-  lines.push("\nThe verifier found unsupported claims. You must perform the required tool verifications before providing a final answer.");
+  lines.push("\nCompliance language ('I verified', 'I checked') is NOT evidence. Perform the required tool calls.");
   return lines.join("\n");
 }
 
 function formatToolBatch(step: number, toolNames: string[]): string {
-  const unique = [...new Set(toolNames)];
-  return `Grok requested tool batch ${step}: ${unique.join(", ")}`;
-}
-
-function summarizeToolResult(result: Awaited<ReturnType<ToolRegistry["execute"]>>): string {
-  if (!result.ok) return result.error.message;
-  return result.summary ?? JSON.stringify(result.data).slice(0, 240);
+  return `Grok requested tool batch ${step}: ${[...new Set(toolNames)].join(", ")}`;
 }
 
 function formatActionSummary(actions: ToolActionSummary[]): string {
   return actions
-    .map((action) => `- step ${action.step}: ${action.name} ${action.ok ? "ok" : "failed"} - ${action.summary}`)
+    .map((a) => `- step ${a.step}: ${a.name} ${a.ok ? "ok" : "failed"} - ${a.summary}`)
     .join("\n");
 }
 
@@ -367,7 +417,7 @@ export function shouldContinueAfterPlanOnlyResponse(text: string, task: string, 
   const taskLower = task.toLowerCase();
   const saysItWillUseTools = /(brief plan|before first tool call|i'?ll now|i will now|proceeding to|run the first tool|call .*tool|use .*tool|工具)/i.test(text);
   const englishActionTask = /\b(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|issue|pr)\b/i.test(taskLower);
-  const localizedActionTask = ["修 bug", "修改", "修正", "建立", "新增", "刪除", "執行", "执行", "測試", "测试", "建置", "提交", "推送", "審核", "審核", "開pr", "開 issue"].some((keyword) => taskLower.includes(keyword));
+  const localizedActionTask = ["修 bug", "修改", "修正", "建立", "新增", "刪除", "執行", "执行", "測試", "测试", "建置", "提交", "推送", "審核", "審核", "開pr", "開 issue"].some((k) => taskLower.includes(k));
   const claimsNoCapability = /no .*tool available|there is no .*tool|tools limited to/i.test(text.toLowerCase());
   return actionCount === 0 && (englishActionTask || localizedActionTask) && (saysItWillUseTools || claimsNoCapability);
 }

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -11,6 +11,7 @@ import type { ToolSkillRegistry } from "../tool-skills/ToolSkillRegistry.js";
 import { buildModelInput } from "./modelInputBuilder.js";
 import { finalAnswerGate } from "./finalAnswerGate.js";
 import { SituationMemory } from "./SituationMemory.js";
+import { runVerifier } from "./Verifier.js";
 
 type ToolActionSummary = {
   step: number;
@@ -32,16 +33,20 @@ export class AgentLoop {
   ) {}
 
   async run(task: string, oneShot: boolean, signal?: AbortSignal): Promise<string> {
+    const isStateless = this.config.conversationMode === "stateless";
+    const isHybrid = this.config.conversationMode === "hybrid";
+
     let previousResponseId: string | undefined;
+    // tracks whether the next hybrid call should be a fresh stateless call (after a reset)
+    let hybridForceStateless = false;
     let finalText = "";
     const usedToolNames = new Set<string>();
     const toolActionSummaries: ToolActionSummary[] = [];
     let planOnlyReprompts = 0;
     let emptyResponseRetries = 0;
+    let verifierReprompts = 0;
     const hasModifiedFiles = { value: false };
     const situationMemory = new SituationMemory();
-    const isStateless = this.config.conversationMode === "stateless";
-    const isHybrid = this.config.conversationMode === "hybrid";
 
     this.context.upsert("user-task", { type: "user_task", content: task, priority: 100, pinned: true });
 
@@ -52,22 +57,24 @@ export class AgentLoop {
       throwIfAborted(signal);
       this.context.nextStep(task);
 
-      // hybrid mode: reset stateful context after thresholds
-      if (isHybrid && previousResponseId) {
+      // hybrid: reset stateful context after thresholds
+      if (isHybrid && previousResponseId && !hybridForceStateless) {
         const shouldReset =
           step > this.config.hybridResetAfterSteps ||
           situationMemory.totalFailures() >= this.config.hybridResetAfterFailures;
         if (shouldReset) {
           previousResponseId = undefined;
-          pendingInput = this.buildInput(task, situationMemory);
-          console.log(`[hybrid] Context reset at step ${step} — switching to fresh stateless call.`);
+          hybridForceStateless = true;
+          pendingInput = this.buildStatelessPrompt(task, situationMemory);
+          console.log(`[hybrid] Context reset at step ${step} — rebuilding from situation memory.`);
         }
       }
+
+      const useStateless = isStateless || hybridForceStateless;
 
       const spinner = ora(`Grok thinking (step ${step})`).start();
       let response: any;
       try {
-        const useStateless = isStateless || (isHybrid && !previousResponseId);
         response = await createResponse(this.client, {
           model: this.config.model,
           input: pendingInput,
@@ -82,22 +89,18 @@ export class AgentLoop {
 
       throwIfAborted(signal);
       const parsed = parseResponse(response);
+      previousResponseId = parsed.id || previousResponseId;
+      hybridForceStateless = false;
 
-      if (!usesPreviousResponseId(isStateless, isHybrid, previousResponseId)) {
-        previousResponseId = parsed.id || previousResponseId;
-      } else {
-        previousResponseId = parsed.id || previousResponseId;
-      }
-
-      // watchdog: empty response
+      // watchdog: empty response with no tool calls and no text
       if (!parsed.finalText && parsed.functionCalls.length === 0) {
         if (emptyResponseRetries < 1) {
           emptyResponseRetries += 1;
           console.log("[watchdog] Empty response detected. Nudging model to continue.");
           pendingInput = this.buildCorrectionInput(
             task,
-            "Your previous response was empty. Continue by emitting exactly one tool call or a final answer.",
-            isStateless || isHybrid ? situationMemory : undefined
+            "Your previous response was empty. Emit exactly one tool call or a final answer. Do not respond with only whitespace.",
+            useStateless ? situationMemory : undefined
           );
           step += 1;
           continue;
@@ -107,36 +110,44 @@ export class AgentLoop {
       }
       emptyResponseRetries = 0;
 
-      // narration-only: model described intent without a tool call
+      // narration guard: model described intent but did not call a tool
       if (parsed.functionCalls.length === 0) {
         if (planOnlyReprompts < 2 && shouldContinueAfterPlanOnlyResponse(parsed.finalText, task, toolActionSummaries.length)) {
           planOnlyReprompts += 1;
           console.log(parsed.finalText);
-          console.log("Grok provided a plan without tool calls; asking it to continue with the required tools.");
+          console.log("Grok provided a plan without tool calls; requesting actual tool use.");
           pendingInput = this.buildCorrectionInput(
             task,
-            "Invalid response: you stated an intention but did not call a tool. Return exactly one tool call or a final answer. Do not narrate intent without acting.",
-            isStateless || isHybrid ? situationMemory : undefined
+            "Invalid response: you described an intention but did not call a tool. Return exactly one tool call or a final answer. Describing intent is not the same as acting.",
+            useStateless ? situationMemory : undefined
           );
           step += 1;
           continue;
         }
+
+        // candidate final answer — run verifier if enabled
+        if (this.config.enableVerifier && verifierReprompts < 2 && parsed.finalText) {
+          const verifierResult = await this.verify(task, situationMemory, parsed.finalText, signal);
+          if (verifierResult && verifierResult.verdict !== "pass") {
+            verifierReprompts += 1;
+            const correction = buildVerifierCorrection(verifierResult);
+            console.log(`[verifier] verdict=${verifierResult.verdict} confidence=${verifierResult.confidence}`);
+            pendingInput = this.buildCorrectionInput(task, correction, useStateless ? situationMemory : undefined);
+            step += 1;
+            continue;
+          }
+        }
+
         finalText = parsed.finalText;
         break;
       }
 
       planOnlyReprompts = 0;
-      if (parsed.finalText) {
-        console.log(parsed.finalText);
-      }
+      if (parsed.finalText) console.log(parsed.finalText);
       console.log(formatToolBatch(step, parsed.functionCalls.map((call) => call.name)));
 
-      // blind-retry guard: reject repeated failed tool+args before execution
-      const blocked = parsed.functionCalls.find((call) => {
-        let args: unknown;
-        try { args = JSON.parse(call.arguments || "{}"); } catch { return false; }
-        return situationMemory.hasRecentlyFailed(call.name, args);
-      });
+      // blind-retry guard: block repeated failed tool+args before executing
+      const blocked = this.findBlockedCall(parsed.functionCalls, situationMemory);
       if (blocked) {
         let args: unknown;
         try { args = JSON.parse(blocked.arguments || "{}"); } catch { args = {}; }
@@ -145,13 +156,13 @@ export class AgentLoop {
         pendingInput = this.buildCorrectionInput(
           task,
           `BLIND RETRY BLOCKED:\nTool: ${record.tool}\nError: ${record.error}\nAttempts: ${record.attempts}\nConstraint: Do not retry the exact same action unchanged. Choose a different approach: narrow the scope, inspect logs, or change strategy.`,
-          isStateless || isHybrid ? situationMemory : undefined
+          useStateless ? situationMemory : undefined
         );
         step += 1;
         continue;
       }
 
-      const outputs = await this.executeToolBatch(
+      await this.executeToolBatch(
         parsed.functionCalls,
         step,
         usedToolNames,
@@ -161,10 +172,14 @@ export class AgentLoop {
         signal
       );
 
-      if (isStateless || isHybrid) {
-        pendingInput = this.buildInput(task, situationMemory, outputs);
+      // in stateless/hybrid: rebuild fresh prompt from updated situation memory
+      // do NOT pass raw function_call_output protocol items without previous_response_id context
+      if (useStateless || isStateless || isHybrid) {
+        pendingInput = this.buildStatelessPrompt(task, situationMemory);
       } else {
-        pendingInput = outputs;
+        // stateful: xAI API tracks conversation via previous_response_id
+        // just send an empty continuation signal — the API replays context
+        pendingInput = [];
       }
 
       step += 1;
@@ -178,20 +193,15 @@ export class AgentLoop {
       hasModifiedFiles: hasModifiedFiles.value
     });
     const diffSection = gate.diffPreview ? `\n\n[Diff preview]\n${gate.diffPreview}` : "";
-    const actionSection = toolActionSummaries.length > 0 ? `\n\n[Actions completed]\n${formatActionSummary(toolActionSummaries)}` : "";
+    const actionSection = toolActionSummaries.length > 0
+      ? `\n\n[Actions completed]\n${formatActionSummary(toolActionSummaries)}`
+      : "";
     const suffix = `${actionSection}${diffSection}\n\n[Final checks]\nBackground: ${gate.backgroundStatus}\nDiff checked: ${gate.diffChecked ? "yes" : "not needed"}`;
     return finalText ? `${finalText}${suffix}` : `Stopped after max steps without a final model message.${suffix}`;
   }
 
-  private buildInput(task: string, memory?: SituationMemory, toolOutputs?: any[]): any {
-    if (toolOutputs && toolOutputs.length > 0) {
-      // in stateless/hybrid, append tool outputs as part of the fresh prompt context
-      const base = this.buildStatelessPrompt(task, memory);
-      return [{ role: "user", content: base }, ...toolOutputs];
-    }
-    if (memory) {
-      return this.buildStatelessPrompt(task, memory);
-    }
+  private buildInput(task: string, memory?: SituationMemory): string {
+    if (memory) return this.buildStatelessPrompt(task, memory);
     return buildModelInput({
       task,
       context: this.context,
@@ -202,7 +212,7 @@ export class AgentLoop {
     });
   }
 
-  private buildStatelessPrompt(task: string, memory?: SituationMemory): string {
+  private buildStatelessPrompt(task: string, memory: SituationMemory): string {
     return buildModelInput({
       task,
       context: this.context,
@@ -210,13 +220,32 @@ export class AgentLoop {
       generalSkills: this.skillLoader.select(task),
       toolSkills: this.toolSkills.select(task, []),
       projectInstructions: this.projectInstructions,
-      situationSnapshot: memory?.snapshot()
+      situationSnapshot: memory.snapshot()
     });
   }
 
   private buildCorrectionInput(task: string, correction: string, memory?: SituationMemory): string {
     const base = memory ? this.buildStatelessPrompt(task, memory) : "";
     return base ? `${base}\n\n<Correction>\n${correction}\n</Correction>` : correction;
+  }
+
+  private findBlockedCall(
+    functionCalls: Array<{ name: string; arguments?: string; call_id: string }>,
+    memory: SituationMemory
+  ): { name: string; arguments?: string; call_id: string } | undefined {
+    return functionCalls.find((call) => {
+      let args: unknown;
+      try { args = JSON.parse(call.arguments || "{}"); } catch { return false; }
+      return memory.hasRecentlyFailed(call.name, args) !== undefined;
+    });
+  }
+
+  private async verify(task: string, memory: SituationMemory, executorClaim: string, signal?: AbortSignal) {
+    try {
+      return await runVerifier(this.client, this.config.model, task, memory.getEvidence(), executorClaim, signal);
+    } catch {
+      return null;
+    }
   }
 
   private async executeToolBatch(
@@ -227,23 +256,23 @@ export class AgentLoop {
     hasModifiedFiles: { value: boolean },
     situationMemory: SituationMemory,
     signal?: AbortSignal
-  ): Promise<Array<{ type: "function_call_output"; call_id: string; output: string }>> {
-    const outputs: Array<{ type: "function_call_output"; call_id: string; output: string }> = [];
+  ): Promise<void> {
     for (let index = 0; index < functionCalls.length;) {
       const call = functionCalls[index];
       if (this.tools.isReadOnly(call.name)) {
-        const readOnlyCalls = [];
+        const readOnlyCalls: typeof functionCalls = [];
         while (index < functionCalls.length && this.tools.isReadOnly(functionCalls[index].name)) {
           readOnlyCalls.push(functionCalls[index]);
           index += 1;
         }
-        outputs.push(...await Promise.all(readOnlyCalls.map((item) => this.executeOneToolCall(item, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal))));
+        await Promise.all(readOnlyCalls.map((item) =>
+          this.executeOneToolCall(item, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal)
+        ));
         continue;
       }
-      outputs.push(await this.executeOneToolCall(call, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal));
+      await this.executeOneToolCall(call, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal);
       index += 1;
     }
-    return outputs;
   }
 
   private async executeOneToolCall(
@@ -254,16 +283,17 @@ export class AgentLoop {
     hasModifiedFiles: { value: boolean },
     situationMemory: SituationMemory,
     signal?: AbortSignal
-  ): Promise<{ type: "function_call_output"; call_id: string; output: string }> {
+  ): Promise<void> {
     throwIfAborted(signal);
     usedToolNames.add(call.name);
     let args: unknown;
     try {
       args = JSON.parse(call.arguments || "{}");
     } catch (error) {
-      const result = { ok: false, error: { code: "json_parse_error", message: error instanceof Error ? error.message : String(error) } };
-      situationMemory.recordFailure(call.name, {}, "JSON parse error", step);
-      return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
+      const msg = error instanceof Error ? error.message : String(error);
+      situationMemory.recordFailure(call.name, {}, `JSON parse error: ${msg}`, step);
+      toolActionSummaries.push({ step, name: call.name, ok: false, summary: `JSON parse error: ${msg}` });
+      return;
     }
     const result = await this.tools.execute(call.name, args, this.toolCtx);
     throwIfAborted(signal);
@@ -272,10 +302,12 @@ export class AgentLoop {
     const summary = summarizeToolResult(result);
     toolActionSummaries.push({ step, name: call.name, ok: result.ok, summary });
 
-    if (result.ok) {
-      situationMemory.recordAction(call.name, args, true, summary);
-    } else {
-      situationMemory.recordAction(call.name, args, false);
+    const outputExcerpt = result.ok
+      ? (result.summary ?? JSON.stringify(result.data).slice(0, 600))
+      : `ERROR: ${result.error.message}`;
+
+    situationMemory.recordEvidence(call.name, args, outputExcerpt, result.ok, step);
+    if (!result.ok) {
       situationMemory.recordFailure(call.name, args, result.error.message, step);
     }
 
@@ -285,12 +317,33 @@ export class AgentLoop {
       priority: 45,
       expiresAfterSteps: 2
     });
-    return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
   }
 }
 
-function usesPreviousResponseId(isStateless: boolean, isHybrid: boolean, previousResponseId: string | undefined): boolean {
-  return !isStateless && !(isHybrid && !previousResponseId);
+function buildVerifierCorrection(result: Awaited<ReturnType<typeof runVerifier>>): string {
+  if (!result) return "";
+  const lines = [
+    `VERIFIER AUDIT — verdict: ${result.verdict} (confidence: ${result.confidence})`,
+    `Reason: ${result.reason}`
+  ];
+  if (result.unsupported_assumptions.length > 0) {
+    lines.push("\nUnsupported assumptions detected:");
+    for (const a of result.unsupported_assumptions) {
+      lines.push(`- Claim: ${a.claim}`);
+      lines.push(`  Why unsupported: ${a.why_unsupported}`);
+      lines.push(`  Required verification: ${a.required_verification}`);
+    }
+  }
+  if (result.missing_evidence.length > 0) {
+    lines.push("\nMissing evidence:");
+    for (const e of result.missing_evidence) lines.push(`- ${e}`);
+  }
+  if (result.required_next_actions.length > 0) {
+    lines.push("\nRequired next actions:");
+    for (const a of result.required_next_actions) lines.push(`- ${a}`);
+  }
+  lines.push("\nThe verifier found unsupported claims. You must perform the required tool verifications before providing a final answer.");
+  return lines.join("\n");
 }
 
 function formatToolBatch(step: number, toolNames: string[]): string {
@@ -311,12 +364,11 @@ function formatActionSummary(actions: ToolActionSummary[]): string {
 
 export function shouldContinueAfterPlanOnlyResponse(text: string, task: string, actionCount: number): boolean {
   if (!text.trim()) return false;
-  const lower = text.toLowerCase();
   const taskLower = task.toLowerCase();
   const saysItWillUseTools = /(brief plan|before first tool call|i'?ll now|i will now|proceeding to|run the first tool|call .*tool|use .*tool|工具)/i.test(text);
   const englishActionTask = /\b(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|issue|pr)\b/i.test(taskLower);
   const localizedActionTask = ["修 bug", "修改", "修正", "建立", "新增", "刪除", "執行", "执行", "測試", "测试", "建置", "提交", "推送", "審核", "審核", "開pr", "開 issue"].some((keyword) => taskLower.includes(keyword));
-  const claimsNoCapability = /no .*tool available|there is no .*tool|tools limited to/i.test(lower);
+  const claimsNoCapability = /no .*tool available|there is no .*tool|tools limited to/i.test(text.toLowerCase());
   return actionCount === 0 && (englishActionTask || localizedActionTask) && (saysItWillUseTools || claimsNoCapability);
 }
 

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -133,17 +133,22 @@ export class AgentLoop {
           break;
         }
 
-        if (planOnlyReprompts < 2 && shouldContinueAfterPlanOnlyResponse(parsed.finalText, task, toolActionSummaries.length)) {
-          planOnlyReprompts += 1;
-          console.log(parsed.finalText);
-          console.log("Grok described intent without acting. Requesting tool call.");
-          pendingInput = this.buildCorrectionInput(
-            task,
-            "Invalid response: you described an intention but did not call a tool. Return exactly one tool call or a final answer. Describing intent is not evidence.",
-            useStateless ? situationMemory : undefined
-          );
-          step += 1;
-          continue;
+        if (shouldContinueAfterPlanOnlyResponse(parsed.finalText, task, toolActionSummaries.length)) {
+          if (planOnlyReprompts < 2) {
+            planOnlyReprompts += 1;
+            console.log(parsed.finalText);
+            console.log("Grok described intent without acting. Requesting tool call.");
+            pendingInput = this.buildCorrectionInput(
+              task,
+              "Invalid response: you described an intention but did not call a tool. Return exactly one tool call or a final answer. Describing intent is not evidence.",
+              useStateless ? situationMemory : undefined
+            );
+            step += 1;
+            continue;
+          }
+          // budget exhausted — fail closed, never accept narrated intent as a final answer
+          finalText = "[agent stopped: model repeatedly provided intent without tool action]";
+          break;
         }
 
         // candidate final answer — run verifier if enabled
@@ -173,6 +178,18 @@ export class AgentLoop {
       }
 
       planOnlyReprompts = 0;
+
+      // output-protocol guard: exactly one tool call per non-final turn
+      if (parsed.functionCalls.length > 1) {
+        console.log(`[guard] Rejected ${parsed.functionCalls.length} tool calls in one turn — protocol requires exactly one.`);
+        pendingInput = this.buildCorrectionInput(
+          task,
+          `Invalid: you returned ${parsed.functionCalls.length} tool calls in one turn. Exactly one tool call per turn is required. Return exactly one tool call.`,
+          useStateless ? situationMemory : undefined
+        );
+        step += 1;
+        continue;
+      }
 
       // intermediate claim audit: scan planning text alongside tool calls
       if (parsed.finalText) {

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -10,6 +10,7 @@ import type { SkillLoader } from "../skills/SkillLoader.js";
 import type { ToolSkillRegistry } from "../tool-skills/ToolSkillRegistry.js";
 import { buildModelInput } from "./modelInputBuilder.js";
 import { finalAnswerGate } from "./finalAnswerGate.js";
+import { SituationMemory } from "./SituationMemory.js";
 
 type ToolActionSummary = {
   step: number;
@@ -36,58 +37,136 @@ export class AgentLoop {
     const usedToolNames = new Set<string>();
     const toolActionSummaries: ToolActionSummary[] = [];
     let planOnlyReprompts = 0;
+    let emptyResponseRetries = 0;
     const hasModifiedFiles = { value: false };
+    const situationMemory = new SituationMemory();
+    const isStateless = this.config.conversationMode === "stateless";
+    const isHybrid = this.config.conversationMode === "hybrid";
+
     this.context.upsert("user-task", { type: "user_task", content: task, priority: 100, pinned: true });
 
     let step = 1;
-    let pendingInput: any = buildModelInput({
-      task,
-      context: this.context,
-      toolIndex: this.toolSkills.toolIndex(),
-      generalSkills: this.skillLoader.select(task),
-      toolSkills: this.toolSkills.select(task, []),
-      projectInstructions: this.projectInstructions
-    });
+    let pendingInput: any = this.buildInput(task, isStateless ? situationMemory : undefined);
 
     while (step <= this.config.maxSteps) {
       throwIfAborted(signal);
       this.context.nextStep(task);
+
+      // hybrid mode: reset stateful context after thresholds
+      if (isHybrid && previousResponseId) {
+        const shouldReset =
+          step > this.config.hybridResetAfterSteps ||
+          situationMemory.totalFailures() >= this.config.hybridResetAfterFailures;
+        if (shouldReset) {
+          previousResponseId = undefined;
+          pendingInput = this.buildInput(task, situationMemory);
+          console.log(`[hybrid] Context reset at step ${step} — switching to fresh stateless call.`);
+        }
+      }
+
       const spinner = ora(`Grok thinking (step ${step})`).start();
       let response: any;
       try {
+        const useStateless = isStateless || (isHybrid && !previousResponseId);
         response = await createResponse(this.client, {
           model: this.config.model,
           input: pendingInput,
           tools: this.tools.schemas(serverTools(this.config)),
           toolChoice: this.config.toolChoice,
-          previousResponseId,
+          previousResponseId: useStateless ? undefined : previousResponseId,
           signal
         });
       } finally {
         spinner.stop();
       }
+
       throwIfAborted(signal);
       const parsed = parseResponse(response);
-      previousResponseId = parsed.id || previousResponseId;
+
+      if (!usesPreviousResponseId(isStateless, isHybrid, previousResponseId)) {
+        previousResponseId = parsed.id || previousResponseId;
+      } else {
+        previousResponseId = parsed.id || previousResponseId;
+      }
+
+      // watchdog: empty response
+      if (!parsed.finalText && parsed.functionCalls.length === 0) {
+        if (emptyResponseRetries < 1) {
+          emptyResponseRetries += 1;
+          console.log("[watchdog] Empty response detected. Nudging model to continue.");
+          pendingInput = this.buildCorrectionInput(
+            task,
+            "Your previous response was empty. Continue by emitting exactly one tool call or a final answer.",
+            isStateless || isHybrid ? situationMemory : undefined
+          );
+          step += 1;
+          continue;
+        }
+        finalText = "[agent stopped: repeated empty responses from model]";
+        break;
+      }
+      emptyResponseRetries = 0;
+
+      // narration-only: model described intent without a tool call
       if (parsed.functionCalls.length === 0) {
         if (planOnlyReprompts < 2 && shouldContinueAfterPlanOnlyResponse(parsed.finalText, task, toolActionSummaries.length)) {
           planOnlyReprompts += 1;
           console.log(parsed.finalText);
           console.log("Grok provided a plan without tool calls; asking it to continue with the required tools.");
-          pendingInput = "You provided a plan but did not request any function_call tools. The user asked for an action, not only a plan. Continue now by requesting the appropriate tools in this response. If the action cannot be completed, explain the concrete blocker after using any relevant inspection tools.";
+          pendingInput = this.buildCorrectionInput(
+            task,
+            "Invalid response: you stated an intention but did not call a tool. Return exactly one tool call or a final answer. Do not narrate intent without acting.",
+            isStateless || isHybrid ? situationMemory : undefined
+          );
           step += 1;
           continue;
         }
         finalText = parsed.finalText;
         break;
       }
+
+      planOnlyReprompts = 0;
       if (parsed.finalText) {
         console.log(parsed.finalText);
       }
       console.log(formatToolBatch(step, parsed.functionCalls.map((call) => call.name)));
 
-      const outputs = await this.executeToolBatch(parsed.functionCalls, step, usedToolNames, toolActionSummaries, hasModifiedFiles, signal);
-      pendingInput = outputs;
+      // blind-retry guard: reject repeated failed tool+args before execution
+      const blocked = parsed.functionCalls.find((call) => {
+        let args: unknown;
+        try { args = JSON.parse(call.arguments || "{}"); } catch { return false; }
+        return situationMemory.hasRecentlyFailed(call.name, args);
+      });
+      if (blocked) {
+        let args: unknown;
+        try { args = JSON.parse(blocked.arguments || "{}"); } catch { args = {}; }
+        const record = situationMemory.hasRecentlyFailed(blocked.name, args)!;
+        console.log(`[guard] Blocking blind retry of ${blocked.name} (failed ${record.attempts}x). Injecting failure context.`);
+        pendingInput = this.buildCorrectionInput(
+          task,
+          `BLIND RETRY BLOCKED:\nTool: ${record.tool}\nError: ${record.error}\nAttempts: ${record.attempts}\nConstraint: Do not retry the exact same action unchanged. Choose a different approach: narrow the scope, inspect logs, or change strategy.`,
+          isStateless || isHybrid ? situationMemory : undefined
+        );
+        step += 1;
+        continue;
+      }
+
+      const outputs = await this.executeToolBatch(
+        parsed.functionCalls,
+        step,
+        usedToolNames,
+        toolActionSummaries,
+        hasModifiedFiles,
+        situationMemory,
+        signal
+      );
+
+      if (isStateless || isHybrid) {
+        pendingInput = this.buildInput(task, situationMemory, outputs);
+      } else {
+        pendingInput = outputs;
+      }
+
       step += 1;
     }
 
@@ -104,12 +183,49 @@ export class AgentLoop {
     return finalText ? `${finalText}${suffix}` : `Stopped after max steps without a final model message.${suffix}`;
   }
 
+  private buildInput(task: string, memory?: SituationMemory, toolOutputs?: any[]): any {
+    if (toolOutputs && toolOutputs.length > 0) {
+      // in stateless/hybrid, append tool outputs as part of the fresh prompt context
+      const base = this.buildStatelessPrompt(task, memory);
+      return [{ role: "user", content: base }, ...toolOutputs];
+    }
+    if (memory) {
+      return this.buildStatelessPrompt(task, memory);
+    }
+    return buildModelInput({
+      task,
+      context: this.context,
+      toolIndex: this.toolSkills.toolIndex(),
+      generalSkills: this.skillLoader.select(task),
+      toolSkills: this.toolSkills.select(task, []),
+      projectInstructions: this.projectInstructions
+    });
+  }
+
+  private buildStatelessPrompt(task: string, memory?: SituationMemory): string {
+    return buildModelInput({
+      task,
+      context: this.context,
+      toolIndex: this.toolSkills.toolIndex(),
+      generalSkills: this.skillLoader.select(task),
+      toolSkills: this.toolSkills.select(task, []),
+      projectInstructions: this.projectInstructions,
+      situationSnapshot: memory?.snapshot()
+    });
+  }
+
+  private buildCorrectionInput(task: string, correction: string, memory?: SituationMemory): string {
+    const base = memory ? this.buildStatelessPrompt(task, memory) : "";
+    return base ? `${base}\n\n<Correction>\n${correction}\n</Correction>` : correction;
+  }
+
   private async executeToolBatch(
     functionCalls: Array<{ name: string; arguments?: string; call_id: string }>,
     step: number,
     usedToolNames: Set<string>,
     toolActionSummaries: ToolActionSummary[],
     hasModifiedFiles: { value: boolean },
+    situationMemory: SituationMemory,
     signal?: AbortSignal
   ): Promise<Array<{ type: "function_call_output"; call_id: string; output: string }>> {
     const outputs: Array<{ type: "function_call_output"; call_id: string; output: string }> = [];
@@ -121,10 +237,10 @@ export class AgentLoop {
           readOnlyCalls.push(functionCalls[index]);
           index += 1;
         }
-        outputs.push(...await Promise.all(readOnlyCalls.map((item) => this.executeOneToolCall(item, step, usedToolNames, toolActionSummaries, hasModifiedFiles, signal))));
+        outputs.push(...await Promise.all(readOnlyCalls.map((item) => this.executeOneToolCall(item, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal))));
         continue;
       }
-      outputs.push(await this.executeOneToolCall(call, step, usedToolNames, toolActionSummaries, hasModifiedFiles, signal));
+      outputs.push(await this.executeOneToolCall(call, step, usedToolNames, toolActionSummaries, hasModifiedFiles, situationMemory, signal));
       index += 1;
     }
     return outputs;
@@ -136,6 +252,7 @@ export class AgentLoop {
     usedToolNames: Set<string>,
     toolActionSummaries: ToolActionSummary[],
     hasModifiedFiles: { value: boolean },
+    situationMemory: SituationMemory,
     signal?: AbortSignal
   ): Promise<{ type: "function_call_output"; call_id: string; output: string }> {
     throwIfAborted(signal);
@@ -145,17 +262,23 @@ export class AgentLoop {
       args = JSON.parse(call.arguments || "{}");
     } catch (error) {
       const result = { ok: false, error: { code: "json_parse_error", message: error instanceof Error ? error.message : String(error) } };
+      situationMemory.recordFailure(call.name, {}, "JSON parse error", step);
       return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
     }
     const result = await this.tools.execute(call.name, args, this.toolCtx);
     throwIfAborted(signal);
     if (call.name === "apply_patch" && result.ok) hasModifiedFiles.value = true;
-    toolActionSummaries.push({
-      step,
-      name: call.name,
-      ok: result.ok,
-      summary: summarizeToolResult(result)
-    });
+
+    const summary = summarizeToolResult(result);
+    toolActionSummaries.push({ step, name: call.name, ok: result.ok, summary });
+
+    if (result.ok) {
+      situationMemory.recordAction(call.name, args, true, summary);
+    } else {
+      situationMemory.recordAction(call.name, args, false);
+      situationMemory.recordFailure(call.name, args, result.error.message, step);
+    }
+
     this.context.add({
       type: "shell_output",
       content: `tool ${call.name}(${call.arguments}) => ${JSON.stringify(result).slice(0, 4000)}`,
@@ -164,6 +287,10 @@ export class AgentLoop {
     });
     return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
   }
+}
+
+function usesPreviousResponseId(isStateless: boolean, isHybrid: boolean, previousResponseId: string | undefined): boolean {
+  return !isStateless && !(isHybrid && !previousResponseId);
 }
 
 function formatToolBatch(step: number, toolNames: string[]): string {
@@ -188,7 +315,7 @@ export function shouldContinueAfterPlanOnlyResponse(text: string, task: string, 
   const taskLower = task.toLowerCase();
   const saysItWillUseTools = /(brief plan|before first tool call|i'?ll now|i will now|proceeding to|run the first tool|call .*tool|use .*tool|工具)/i.test(text);
   const englishActionTask = /\b(commit|push|edit|modify|fix|write|create|delete|run|test|build|review|issue|pr)\b/i.test(taskLower);
-  const localizedActionTask = ["\u4fee bug", "\u4fee\u6539", "\u4fee\u6b63", "\u5efa\u7acb", "\u65b0\u589e", "\u522a\u9664", "\u6267\u884c", "\u57f7\u884c", "\u6e2c\u8a66", "\u6d4b\u8bd5", "\u5efa\u7f6e", "\u63d0\u4ea4", "\u63a8\u9001", "\u5be9\u6838", "\u5ba1\u6838", "\u958bpr", "\u958b issue"].some((keyword) => taskLower.includes(keyword));
+  const localizedActionTask = ["修 bug", "修改", "修正", "建立", "新增", "刪除", "執行", "执行", "測試", "测试", "建置", "提交", "推送", "審核", "審核", "開pr", "開 issue"].some((keyword) => taskLower.includes(keyword));
   const claimsNoCapability = /no .*tool available|there is no .*tool|tools limited to/i.test(lower);
   return actionCount === 0 && (englishActionTask || localizedActionTask) && (saysItWillUseTools || claimsNoCapability);
 }

--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -11,7 +11,7 @@ import type { ToolSkillRegistry } from "../tool-skills/ToolSkillRegistry.js";
 import { buildModelInput } from "./modelInputBuilder.js";
 import { finalAnswerGate } from "./finalAnswerGate.js";
 import { SituationMemory } from "./SituationMemory.js";
-import { runVerifier, type VerifierResult } from "./Verifier.js";
+import { runVerifier, auditIntermediateClaims, type VerifierResult } from "./Verifier.js";
 
 type ToolActionSummary = {
   step: number;
@@ -125,6 +125,20 @@ export class AgentLoop {
           continue;
         }
 
+        // block finalization if unresolved pending verifications exist
+        const unresolved = situationMemory.getUnresolvedVerifications();
+        if (this.config.enableVerifier && unresolved.length > 0 && verifierReprompts < 2) {
+          verifierReprompts += 1;
+          console.log(`[verifier] Blocking finalization: ${unresolved.length} unresolved pending verification(s).`);
+          pendingInput = this.buildCorrectionInput(
+            task,
+            buildPendingVerificationBlock(unresolved),
+            useStateless ? situationMemory : undefined
+          );
+          step += 1;
+          continue;
+        }
+
         // candidate final answer — run verifier if enabled
         if (this.config.enableVerifier && parsed.finalText) {
           const accepted = await this.runVerifierLoop(
@@ -159,7 +173,13 @@ export class AgentLoop {
       }
 
       planOnlyReprompts = 0;
-      if (parsed.finalText) console.log(parsed.finalText);
+      if (parsed.finalText) {
+        console.log(parsed.finalText);
+        // intermediate audit: check planning text for unsupported current-state claims
+        if (this.config.enableVerifier) {
+          await this.auditIntermediateText(situationMemory, parsed.finalText, step, signal);
+        }
+      }
       console.log(formatToolBatch(step, parsed.functionCalls.map((call) => call.name)));
 
       // blind-retry guard
@@ -215,6 +235,21 @@ export class AgentLoop {
       : "";
     const suffix = `${actionSection}${diffSection}\n\n[Final checks]\nBackground: ${gate.backgroundStatus}\nDiff checked: ${gate.diffChecked ? "yes" : "not needed"}`;
     return finalText ? `${finalText}${suffix}` : `Stopped after max steps without a final model message.${suffix}`;
+  }
+
+  private async auditIntermediateText(
+    memory: SituationMemory,
+    planningText: string,
+    step: number,
+    signal?: AbortSignal
+  ): Promise<void> {
+    const verifierModel = this.config.verifierModel || this.config.model;
+    const result = await auditIntermediateClaims(this.client, verifierModel, memory.getEvidence(), planningText, signal);
+    if (!result.ok) return; // lenient on intermediate audit failure — don't block tool execution
+    for (const assumption of result.unsupported_assumptions) {
+      memory.addPendingVerification(assumption.claim, assumption.required_verification, step);
+      console.log(`[intermediate audit] Unsupported claim queued for verification: ${assumption.claim.slice(0, 100)}`);
+    }
   }
 
   private async runVerifierLoop(
@@ -375,6 +410,18 @@ export class AgentLoop {
       expiresAfterSteps: 2
     });
   }
+}
+
+function buildPendingVerificationBlock(unresolved: Array<{ claim: string; requiredAction: string }>): string {
+  const lines = [
+    "FINALIZATION BLOCKED: The following claims were identified as unsupported and must be verified with tool calls before a final answer can be accepted:"
+  ];
+  for (const pv of unresolved) {
+    lines.push(`  Claim: ${pv.claim}`);
+    lines.push(`  Required action: ${pv.requiredAction}`);
+  }
+  lines.push("\nCompliance language ('I verified', 'I checked') is NOT evidence. Perform the required tool calls.");
+  return lines.join("\n");
 }
 
 function buildVerifierCorrection(vr: VerifierResult): string {

--- a/src/agent/SituationMemory.ts
+++ b/src/agent/SituationMemory.ts
@@ -1,19 +1,34 @@
 export type MemoryFactSource = "user" | "read_file" | "terminal" | "patch" | "test" | "model_inference";
-export type MemoryFactConfidence = "verified" | "inferred" | "uncertain";
 
-export type MemoryFact = {
-  text: string;
-  source: MemoryFactSource;
-  confidence: MemoryFactConfidence;
-  evidenceRef?: string;
-};
-
+/** Runtime-observed tool evidence — always verified by definition (the tool ran). */
 export type ToolEvidence = {
   step: number;
   tool: string;
   argsText: string;
-  outputExcerpt: string;
+  /** Raw output from the tool result, NOT a model interpretation. */
+  rawOutput: string;
   ok: boolean;
+  // Rich provenance fields populated from tool args/results
+  filePath?: string;
+  lineRange?: { start: number; end: number };
+  exitCode?: number;
+  changedFiles?: string[];
+};
+
+/** A semantic claim extracted from model text — NOT automatically verified. */
+export type SemanticClaim = {
+  text: string;
+  step: number;
+  verified: boolean;
+  evidenceRefs: string[]; // references to ToolEvidence step+tool
+};
+
+/** An unsupported assumption that must be verified before it can enter durable memory. */
+export type PendingVerification = {
+  claim: string;
+  requiredAction: string;
+  addedAtStep: number;
+  resolved: boolean;
 };
 
 export type FailureRecord = {
@@ -25,25 +40,44 @@ export type FailureRecord = {
 };
 
 export class SituationMemory {
-  private facts: MemoryFact[] = [];
-  private priorActions: string[] = [];
-  private failures = new Map<string, FailureRecord>();
   private evidence: ToolEvidence[] = [];
+  private semanticClaims: SemanticClaim[] = [];
+  private pendingVerifications: PendingVerification[] = [];
+  private failures = new Map<string, FailureRecord>();
+  private priorActions: string[] = [];
 
-  recordEvidence(tool: string, args: unknown, outputExcerpt: string, ok: boolean, step: number): void {
+  recordEvidence(tool: string, args: unknown, rawOutput: string, ok: boolean, step: number): void {
     const argsText = JSON.stringify(args).slice(0, 120);
     this.priorActions.push(`${tool}(${argsText})`);
-    this.evidence.push({ step, tool, argsText, outputExcerpt: outputExcerpt.slice(0, 600), ok });
 
-    if (ok) {
-      const ref = `${tool}@step${step}`;
-      this.facts.push({
-        text: `${tool} succeeded: ${outputExcerpt.slice(0, 200)}`,
-        source: this.toolToSource(tool),
-        confidence: "verified",
-        evidenceRef: ref
-      });
+    const ev: ToolEvidence = {
+      step,
+      tool,
+      argsText,
+      rawOutput: rawOutput.slice(0, 800),
+      ok,
+      ...this.extractProvenance(tool, args, rawOutput)
+    };
+    this.evidence.push(ev);
+  }
+
+  addPendingVerification(claim: string, requiredAction: string, step: number): void {
+    const alreadyPending = this.pendingVerifications.some(
+      (p) => !p.resolved && p.claim === claim
+    );
+    if (!alreadyPending) {
+      this.pendingVerifications.push({ claim, requiredAction, addedAtStep: step, resolved: false });
     }
+  }
+
+  resolvePendingVerifications(resolvedClaims: string[]): void {
+    for (const pv of this.pendingVerifications) {
+      if (resolvedClaims.includes(pv.claim)) pv.resolved = true;
+    }
+  }
+
+  getUnresolvedVerifications(): PendingVerification[] {
+    return this.pendingVerifications.filter((p) => !p.resolved);
   }
 
   recordFailure(tool: string, args: unknown, error: string, step: number): void {
@@ -54,13 +88,7 @@ export class SituationMemory {
       existing.error = error;
       existing.lastAttemptStep = step;
     } else {
-      this.failures.set(key, {
-        tool,
-        normalizedArgs: JSON.stringify(args),
-        error,
-        attempts: 1,
-        lastAttemptStep: step
-      });
+      this.failures.set(key, { tool, normalizedArgs: JSON.stringify(args), error, attempts: 1, lastAttemptStep: step });
     }
   }
 
@@ -89,48 +117,82 @@ export class SituationMemory {
   snapshot(): string {
     const lines: string[] = [];
 
-    lines.push("Current workspace state is UNKNOWN until observed via tools.");
-    lines.push("Do not infer or assume file contents, test results, or environment state without tool evidence.");
+    lines.push("EPISTEMIC STANCE: Current workspace state is UNKNOWN until observed via tools.");
+    lines.push("Do not infer or assume file contents, test results, or environment state.");
+    lines.push("Tool success is verified. Your interpretation of tool output is NOT automatically verified.");
 
     if (this.priorActions.length > 0) {
-      lines.push("\nPrior local agent actions (runtime-observed, not user actions):");
-      for (const action of this.priorActions.slice(-20)) lines.push(`- ${action}`);
+      lines.push("\nPrior runtime actions (observed by the local agent runtime, not the user):");
+      for (const a of this.priorActions.slice(-20)) lines.push(`  - ${a}`);
     }
 
-    const recentEvidence = this.evidence.filter((e) => e.ok).slice(-8);
-    if (recentEvidence.length > 0) {
-      lines.push("\nVerified runtime observations (evidence-backed only):");
-      for (const ev of recentEvidence) {
-        lines.push(`- [step ${ev.step}] ${ev.tool}(${ev.argsText}): ${ev.outputExcerpt.slice(0, 200)}`);
+    const okEvidence = this.evidence.filter((e) => e.ok).slice(-8);
+    if (okEvidence.length > 0) {
+      lines.push("\nVerified runtime observations (raw tool results — NOT model interpretations):");
+      for (const ev of okEvidence) {
+        const provenance = this.formatProvenance(ev);
+        lines.push(`  [step ${ev.step}] ${ev.tool}${provenance}: ${ev.rawOutput.slice(0, 200)}`);
+      }
+    }
+
+    const pending = this.getUnresolvedVerifications();
+    if (pending.length > 0) {
+      lines.push("\nPENDING VERIFICATIONS — you MUST complete these before submitting a final answer:");
+      for (const pv of pending) {
+        lines.push(`  - Claim: ${pv.claim}`);
+        lines.push(`    Required action: ${pv.requiredAction}`);
       }
     }
 
     const lastFailure = this.getLastFailure();
     if (lastFailure) {
-      lines.push("\nLast failure - MUST NOT repeat blindly:");
+      lines.push("\nLast failure — MUST NOT repeat blindly:");
       lines.push(`  Tool: ${lastFailure.tool}`);
       lines.push(`  Error: ${lastFailure.error}`);
       lines.push(`  Attempts: ${lastFailure.attempts}`);
-      lines.push("  Constraint: Do not retry the exact same action unchanged. Choose a different approach.");
+      lines.push("  Constraint: Choose a different approach. Do not retry the exact same action.");
     }
 
     lines.push("\nEpistemic constraints:");
-    lines.push("- Claims about file contents must be backed by read_file_range evidence.");
-    lines.push("- Claims that tests pass must be backed by a test command with exit status 0.");
-    lines.push("- Claims that patches were applied must be backed by apply_patch success.");
-    lines.push("- Do not present inferred facts as confirmed.");
+    lines.push("  - File contents: must be backed by read_file_range evidence (tool + path + lines).");
+    lines.push("  - Tests passing: must be backed by a test command with exit code 0.");
+    lines.push("  - Patches applied: must be backed by apply_patch success with changed file list.");
+    lines.push("  - Compliance language ('I verified...', 'I checked...') is NOT evidence.");
 
     return lines.join("\n");
   }
 
-  private failureKey(tool: string, args: unknown): string {
-    return `${tool}::${JSON.stringify(args)}`;
+  private extractProvenance(tool: string, args: unknown, rawOutput: string): Partial<ToolEvidence> {
+    const a = args as Record<string, unknown>;
+    const provenance: Partial<ToolEvidence> = {};
+
+    if (tool === "read_file_range") {
+      if (typeof a.path === "string") provenance.filePath = a.path;
+      if (typeof a.start === "number" && typeof a.end === "number") {
+        provenance.lineRange = { start: a.start, end: a.end };
+      }
+    } else if (tool === "apply_patch") {
+      if (typeof a.path === "string") provenance.filePath = a.path;
+      const filesMatch = rawOutput.match(/changed files?: (.+)/i);
+      if (filesMatch) provenance.changedFiles = filesMatch[1].split(",").map((f) => f.trim());
+    } else if (tool === "run_shell" || tool === "start_background_command") {
+      const exitMatch = rawOutput.match(/exit(?:_?code)?[:\s]+(\d+)/i);
+      if (exitMatch) provenance.exitCode = parseInt(exitMatch[1], 10);
+    }
+
+    return provenance;
   }
 
-  private toolToSource(tool: string): MemoryFactSource {
-    if (tool === "read_file_range" || tool === "get_file_overview" || tool === "list_files") return "read_file";
-    if (tool === "apply_patch") return "patch";
-    if (tool.includes("test")) return "test";
-    return "terminal";
+  private formatProvenance(ev: ToolEvidence): string {
+    const parts: string[] = [];
+    if (ev.filePath) parts.push(ev.filePath);
+    if (ev.lineRange) parts.push(`L${ev.lineRange.start}-${ev.lineRange.end}`);
+    if (ev.exitCode !== undefined) parts.push(`exit=${ev.exitCode}`);
+    if (ev.changedFiles?.length) parts.push(`files=${ev.changedFiles.join(",")}`);
+    return parts.length ? `(${parts.join(" ")})` : "";
+  }
+
+  private failureKey(tool: string, args: unknown): string {
+    return `${tool}::${JSON.stringify(args)}`;
   }
 }

--- a/src/agent/SituationMemory.ts
+++ b/src/agent/SituationMemory.ts
@@ -1,0 +1,114 @@
+export type MemoryFactSource = "user" | "read_file" | "terminal" | "patch" | "test" | "model_inference";
+export type MemoryFactConfidence = "verified" | "inferred" | "uncertain";
+
+export type MemoryFact = {
+  text: string;
+  source: MemoryFactSource;
+  confidence: MemoryFactConfidence;
+};
+
+export type FailureRecord = {
+  tool: string;
+  normalizedArgs: string;
+  error: string;
+  attempts: number;
+  lastAttemptStep: number;
+};
+
+export class SituationMemory {
+  private facts: MemoryFact[] = [];
+  private priorActions: string[] = [];
+  private failures = new Map<string, FailureRecord>();
+
+  recordAction(tool: string, args: unknown, ok: boolean, resultSummary?: string): void {
+    const argsStr = JSON.stringify(args).slice(0, 120);
+    this.priorActions.push(`${tool}(${argsStr})`);
+    if (ok && resultSummary) {
+      this.facts.push({
+        text: `${tool}: ${resultSummary}`,
+        source: this.toolToSource(tool),
+        confidence: "verified"
+      });
+    }
+  }
+
+  recordFailure(tool: string, args: unknown, error: string, step: number): void {
+    const key = this.failureKey(tool, args);
+    const existing = this.failures.get(key);
+    if (existing) {
+      existing.attempts += 1;
+      existing.error = error;
+      existing.lastAttemptStep = step;
+    } else {
+      this.failures.set(key, {
+        tool,
+        normalizedArgs: JSON.stringify(args),
+        error,
+        attempts: 1,
+        lastAttemptStep: step
+      });
+    }
+  }
+
+  hasRecentlyFailed(tool: string, args: unknown): FailureRecord | undefined {
+    return this.failures.get(this.failureKey(tool, args));
+  }
+
+  getLastFailure(): FailureRecord | undefined {
+    let latest: FailureRecord | undefined;
+    for (const record of this.failures.values()) {
+      if (!latest || record.lastAttemptStep > latest.lastAttemptStep) {
+        latest = record;
+      }
+    }
+    return latest;
+  }
+
+  totalFailures(): number {
+    let total = 0;
+    for (const record of this.failures.values()) total += record.attempts;
+    return total;
+  }
+
+  snapshot(): string {
+    const lines: string[] = [];
+
+    if (this.priorActions.length > 0) {
+      lines.push("Prior local agent actions:");
+      for (const action of this.priorActions.slice(-20)) lines.push(`- ${action}`);
+    }
+
+    const verified = this.facts.filter((f) => f.confidence === "verified").slice(-10);
+    if (verified.length > 0) {
+      lines.push("\nVerified workspace / runtime observations:");
+      for (const fact of verified) lines.push(`- [${fact.source}] ${fact.text}`);
+    }
+
+    const lastFailure = this.getLastFailure();
+    if (lastFailure) {
+      lines.push("\nLast failure - MUST NOT repeat blindly:");
+      lines.push(`  Tool: ${lastFailure.tool}`);
+      lines.push(`  Error: ${lastFailure.error}`);
+      lines.push(`  Attempts: ${lastFailure.attempts}`);
+      lines.push("  Constraint: Do not retry the exact same action unchanged. Choose a different approach.");
+    }
+
+    lines.push("\nKnown constraints:");
+    lines.push("- Do not claim tests pass unless a test command actually passed.");
+    lines.push("- Do not infer file contents without reading the file via a tool.");
+    lines.push("- Treat verified facts as authoritative. Treat inferred facts as hypotheses requiring tool verification.");
+
+    return lines.join("\n");
+  }
+
+  private failureKey(tool: string, args: unknown): string {
+    return `${tool}::${JSON.stringify(args)}`;
+  }
+
+  private toolToSource(tool: string): MemoryFactSource {
+    if (tool === "read_file_range" || tool === "get_file_overview" || tool === "list_files") return "read_file";
+    if (tool === "apply_patch") return "patch";
+    if (tool.includes("test")) return "test";
+    return "terminal";
+  }
+}

--- a/src/agent/SituationMemory.ts
+++ b/src/agent/SituationMemory.ts
@@ -5,6 +5,15 @@ export type MemoryFact = {
   text: string;
   source: MemoryFactSource;
   confidence: MemoryFactConfidence;
+  evidenceRef?: string;
+};
+
+export type ToolEvidence = {
+  step: number;
+  tool: string;
+  argsText: string;
+  outputExcerpt: string;
+  ok: boolean;
 };
 
 export type FailureRecord = {
@@ -19,15 +28,20 @@ export class SituationMemory {
   private facts: MemoryFact[] = [];
   private priorActions: string[] = [];
   private failures = new Map<string, FailureRecord>();
+  private evidence: ToolEvidence[] = [];
 
-  recordAction(tool: string, args: unknown, ok: boolean, resultSummary?: string): void {
-    const argsStr = JSON.stringify(args).slice(0, 120);
-    this.priorActions.push(`${tool}(${argsStr})`);
-    if (ok && resultSummary) {
+  recordEvidence(tool: string, args: unknown, outputExcerpt: string, ok: boolean, step: number): void {
+    const argsText = JSON.stringify(args).slice(0, 120);
+    this.priorActions.push(`${tool}(${argsText})`);
+    this.evidence.push({ step, tool, argsText, outputExcerpt: outputExcerpt.slice(0, 600), ok });
+
+    if (ok) {
+      const ref = `${tool}@step${step}`;
       this.facts.push({
-        text: `${tool}: ${resultSummary}`,
+        text: `${tool} succeeded: ${outputExcerpt.slice(0, 200)}`,
         source: this.toolToSource(tool),
-        confidence: "verified"
+        confidence: "verified",
+        evidenceRef: ref
       });
     }
   }
@@ -57,9 +71,7 @@ export class SituationMemory {
   getLastFailure(): FailureRecord | undefined {
     let latest: FailureRecord | undefined;
     for (const record of this.failures.values()) {
-      if (!latest || record.lastAttemptStep > latest.lastAttemptStep) {
-        latest = record;
-      }
+      if (!latest || record.lastAttemptStep > latest.lastAttemptStep) latest = record;
     }
     return latest;
   }
@@ -70,18 +82,27 @@ export class SituationMemory {
     return total;
   }
 
+  getEvidence(): ToolEvidence[] {
+    return this.evidence;
+  }
+
   snapshot(): string {
     const lines: string[] = [];
 
+    lines.push("Current workspace state is UNKNOWN until observed via tools.");
+    lines.push("Do not infer or assume file contents, test results, or environment state without tool evidence.");
+
     if (this.priorActions.length > 0) {
-      lines.push("Prior local agent actions:");
+      lines.push("\nPrior local agent actions (runtime-observed, not user actions):");
       for (const action of this.priorActions.slice(-20)) lines.push(`- ${action}`);
     }
 
-    const verified = this.facts.filter((f) => f.confidence === "verified").slice(-10);
-    if (verified.length > 0) {
-      lines.push("\nVerified workspace / runtime observations:");
-      for (const fact of verified) lines.push(`- [${fact.source}] ${fact.text}`);
+    const recentEvidence = this.evidence.filter((e) => e.ok).slice(-8);
+    if (recentEvidence.length > 0) {
+      lines.push("\nVerified runtime observations (evidence-backed only):");
+      for (const ev of recentEvidence) {
+        lines.push(`- [step ${ev.step}] ${ev.tool}(${ev.argsText}): ${ev.outputExcerpt.slice(0, 200)}`);
+      }
     }
 
     const lastFailure = this.getLastFailure();
@@ -93,10 +114,11 @@ export class SituationMemory {
       lines.push("  Constraint: Do not retry the exact same action unchanged. Choose a different approach.");
     }
 
-    lines.push("\nKnown constraints:");
-    lines.push("- Do not claim tests pass unless a test command actually passed.");
-    lines.push("- Do not infer file contents without reading the file via a tool.");
-    lines.push("- Treat verified facts as authoritative. Treat inferred facts as hypotheses requiring tool verification.");
+    lines.push("\nEpistemic constraints:");
+    lines.push("- Claims about file contents must be backed by read_file_range evidence.");
+    lines.push("- Claims that tests pass must be backed by a test command with exit status 0.");
+    lines.push("- Claims that patches were applied must be backed by apply_patch success.");
+    lines.push("- Do not present inferred facts as confirmed.");
 
     return lines.join("\n");
   }

--- a/src/agent/SituationMemory.ts
+++ b/src/agent/SituationMemory.ts
@@ -6,14 +6,13 @@ export type ToolEvidence = {
   /** Raw output from the tool result, NOT a model interpretation. */
   rawOutput: string;
   ok: boolean;
-  // Rich provenance fields populated from tool args/results
   filePath?: string;
   lineRange?: { start: number; end: number };
   exitCode?: number;
   changedFiles?: string[];
 };
 
-/** An unsupported assumption that must be verified before it can enter durable memory. */
+/** An unsupported assumption that must be verified via tool evidence before it can be accepted. */
 export type PendingVerification = {
   claim: string;
   requiredAction: string;
@@ -34,26 +33,31 @@ export class SituationMemory {
   private pendingVerifications: PendingVerification[] = [];
   private failures = new Map<string, FailureRecord>();
   private priorActions: string[] = [];
+  private intermediateAuditFailures = 0;
 
   recordEvidence(tool: string, args: unknown, rawOutput: string, ok: boolean, step: number): void {
-    const argsText = JSON.stringify(args).slice(0, 120);
+    const argsText = stableStringify(tool, args).slice(0, 120);
     this.priorActions.push(`${tool}(${argsText})`);
-
-    const ev: ToolEvidence = {
+    this.evidence.push({
       step,
       tool,
       argsText,
       rawOutput: rawOutput.slice(0, 800),
       ok,
-      ...this.extractProvenance(tool, args, rawOutput)
-    };
-    this.evidence.push(ev);
+      ...extractProvenance(tool, args, rawOutput)
+    });
+  }
+
+  recordAuditFailure(): void {
+    this.intermediateAuditFailures += 1;
+  }
+
+  hasAuditFailures(): boolean {
+    return this.intermediateAuditFailures > 0;
   }
 
   addPendingVerification(claim: string, requiredAction: string, step: number): void {
-    const alreadyPending = this.pendingVerifications.some(
-      (p) => !p.resolved && p.claim === claim
-    );
+    const alreadyPending = this.pendingVerifications.some((p) => !p.resolved && p.claim === claim);
     if (!alreadyPending) {
       this.pendingVerifications.push({ claim, requiredAction, addedAtStep: step, resolved: false });
     }
@@ -77,7 +81,7 @@ export class SituationMemory {
       existing.error = error;
       existing.lastAttemptStep = step;
     } else {
-      this.failures.set(key, { tool, normalizedArgs: JSON.stringify(args), error, attempts: 1, lastAttemptStep: step });
+      this.failures.set(key, { tool, normalizedArgs: stableStringify(tool, args), error, attempts: 1, lastAttemptStep: step });
     }
   }
 
@@ -107,26 +111,29 @@ export class SituationMemory {
     const lines: string[] = [];
 
     lines.push("EPISTEMIC STANCE: Current workspace state is UNKNOWN until observed via tools.");
-    lines.push("Do not infer or assume file contents, test results, or environment state.");
     lines.push("Tool success is verified. Your interpretation of tool output is NOT automatically verified.");
+    lines.push("Compliance language ('I verified', 'I checked') is NOT evidence.");
+
+    if (this.intermediateAuditFailures > 0) {
+      lines.push(`\nWARNING: ${this.intermediateAuditFailures} intermediate claim audit(s) failed. Final verification will be stricter.`);
+    }
 
     if (this.priorActions.length > 0) {
-      lines.push("\nPrior runtime actions (observed by the local agent runtime, not the user):");
+      lines.push("\nPrior runtime actions (observed by the agent runtime, not the user):");
       for (const a of this.priorActions.slice(-20)) lines.push(`  - ${a}`);
     }
 
     const okEvidence = this.evidence.filter((e) => e.ok).slice(-8);
     if (okEvidence.length > 0) {
-      lines.push("\nVerified runtime observations (raw tool results — NOT model interpretations):");
+      lines.push("\nVerified runtime observations (raw tool output — NOT model interpretations):");
       for (const ev of okEvidence) {
-        const provenance = this.formatProvenance(ev);
-        lines.push(`  [step ${ev.step}] ${ev.tool}${provenance}: ${ev.rawOutput.slice(0, 200)}`);
+        lines.push(`  [step ${ev.step}] ${ev.tool}${formatProvenance(ev)}: ${ev.rawOutput.slice(0, 200)}`);
       }
     }
 
     const pending = this.getUnresolvedVerifications();
     if (pending.length > 0) {
-      lines.push("\nPENDING VERIFICATIONS — you MUST complete these before submitting a final answer:");
+      lines.push("\nPENDING VERIFICATIONS — MUST be resolved with tool evidence before final answer:");
       for (const pv of pending) {
         lines.push(`  - Claim: ${pv.claim}`);
         lines.push(`    Required action: ${pv.requiredAction}`);
@@ -136,52 +143,60 @@ export class SituationMemory {
     const lastFailure = this.getLastFailure();
     if (lastFailure) {
       lines.push("\nLast failure — MUST NOT repeat blindly:");
-      lines.push(`  Tool: ${lastFailure.tool}`);
-      lines.push(`  Error: ${lastFailure.error}`);
-      lines.push(`  Attempts: ${lastFailure.attempts}`);
-      lines.push("  Constraint: Choose a different approach. Do not retry the exact same action.");
+      lines.push(`  Tool: ${lastFailure.tool} | Error: ${lastFailure.error} | Attempts: ${lastFailure.attempts}`);
+      lines.push("  Constraint: Choose a different approach.");
     }
 
     lines.push("\nEpistemic constraints:");
-    lines.push("  - File contents: must be backed by read_file_range evidence (tool + path + lines).");
-    lines.push("  - Tests passing: must be backed by a test command with exit code 0.");
+    lines.push("  - File contents: must be backed by read_file_range (path + line range).");
+    lines.push("  - Tests passing: must be backed by run_shell with exit code 0.");
     lines.push("  - Patches applied: must be backed by apply_patch success with changed file list.");
-    lines.push("  - Compliance language ('I verified...', 'I checked...') is NOT evidence.");
 
     return lines.join("\n");
   }
 
-  private extractProvenance(tool: string, args: unknown, rawOutput: string): Partial<ToolEvidence> {
-    const a = args as Record<string, unknown>;
-    const provenance: Partial<ToolEvidence> = {};
-
-    if (tool === "read_file_range") {
-      if (typeof a.path === "string") provenance.filePath = a.path;
-      if (typeof a.start === "number" && typeof a.end === "number") {
-        provenance.lineRange = { start: a.start, end: a.end };
-      }
-    } else if (tool === "apply_patch") {
-      if (typeof a.path === "string") provenance.filePath = a.path;
-      const filesMatch = rawOutput.match(/changed files?: (.+)/i);
-      if (filesMatch) provenance.changedFiles = filesMatch[1].split(",").map((f) => f.trim());
-    } else if (tool === "run_shell" || tool === "start_background_command") {
-      const exitMatch = rawOutput.match(/exit(?:_?code)?[:\s]+(\d+)/i);
-      if (exitMatch) provenance.exitCode = parseInt(exitMatch[1], 10);
-    }
-
-    return provenance;
-  }
-
-  private formatProvenance(ev: ToolEvidence): string {
-    const parts: string[] = [];
-    if (ev.filePath) parts.push(ev.filePath);
-    if (ev.lineRange) parts.push(`L${ev.lineRange.start}-${ev.lineRange.end}`);
-    if (ev.exitCode !== undefined) parts.push(`exit=${ev.exitCode}`);
-    if (ev.changedFiles?.length) parts.push(`files=${ev.changedFiles.join(",")}`);
-    return parts.length ? `(${parts.join(" ")})` : "";
-  }
-
   private failureKey(tool: string, args: unknown): string {
-    return `${tool}::${JSON.stringify(args)}`;
+    return `${tool}::${stableStringify(tool, args)}`;
   }
+}
+
+/** Stable, normalized argument serialization to avoid bypass via key ordering or whitespace. */
+function stableStringify(tool: string, args: unknown): string {
+  if (typeof args !== "object" || args === null) return String(args);
+  const a = args as Record<string, unknown>;
+  const keys = Object.keys(a).sort();
+  const parts = keys.map((k) => {
+    let val = a[k];
+    if (typeof val === "string" && (tool === "run_shell" || tool === "start_background_command") && k === "command") {
+      val = val.replace(/\s+/g, " ").trim();
+    }
+    return `${k}:${JSON.stringify(val)}`;
+  });
+  return parts.join(",");
+}
+
+function extractProvenance(tool: string, args: unknown, rawOutput: string): Partial<ToolEvidence> {
+  const a = args as Record<string, unknown>;
+  const p: Partial<ToolEvidence> = {};
+  if (tool === "read_file_range") {
+    if (typeof a.path === "string") p.filePath = a.path;
+    if (typeof a.start === "number" && typeof a.end === "number") p.lineRange = { start: a.start, end: a.end };
+  } else if (tool === "apply_patch") {
+    if (typeof a.path === "string") p.filePath = a.path;
+    const m = rawOutput.match(/changed files?: (.+)/i);
+    if (m) p.changedFiles = m[1].split(",").map((f) => f.trim());
+  } else if (tool === "run_shell" || tool === "start_background_command") {
+    const m = rawOutput.match(/exit(?:_?code)?[:\s]+(\d+)/i);
+    if (m) p.exitCode = parseInt(m[1], 10);
+  }
+  return p;
+}
+
+function formatProvenance(ev: ToolEvidence): string {
+  const parts: string[] = [];
+  if (ev.filePath) parts.push(ev.filePath);
+  if (ev.lineRange) parts.push(`L${ev.lineRange.start}-${ev.lineRange.end}`);
+  if (ev.exitCode !== undefined) parts.push(`exit=${ev.exitCode}`);
+  if (ev.changedFiles?.length) parts.push(`files=${ev.changedFiles.join(",")}`);
+  return parts.length ? `(${parts.join(" ")})` : "";
 }

--- a/src/agent/SituationMemory.ts
+++ b/src/agent/SituationMemory.ts
@@ -6,6 +6,8 @@ export type ToolEvidence = {
   /** Raw output from the tool result, NOT a model interpretation. */
   rawOutput: string;
   ok: boolean;
+  /** verified = tool succeeded and output is a direct observation; uncertain = tool failed */
+  confidence: "verified" | "uncertain";
   filePath?: string;
   lineRange?: { start: number; end: number };
   exitCode?: number;
@@ -44,6 +46,7 @@ export class SituationMemory {
       argsText,
       rawOutput: rawOutput.slice(0, 800),
       ok,
+      confidence: ok ? "verified" : "uncertain",
       ...extractProvenance(tool, args, rawOutput)
     });
   }
@@ -127,7 +130,14 @@ export class SituationMemory {
     if (okEvidence.length > 0) {
       lines.push("\nVerified runtime observations (raw tool output — NOT model interpretations):");
       for (const ev of okEvidence) {
-        lines.push(`  [step ${ev.step}] ${ev.tool}${formatProvenance(ev)}: ${ev.rawOutput.slice(0, 200)}`);
+        lines.push(`  [step ${ev.step}] [${ev.confidence.toUpperCase()}] ${ev.tool}${formatProvenance(ev)}: ${ev.rawOutput.slice(0, 200)}`);
+      }
+    }
+    const failedEvidence = this.evidence.filter((e) => !e.ok).slice(-4);
+    if (failedEvidence.length > 0) {
+      lines.push("\nFailed/uncertain observations:");
+      for (const ev of failedEvidence) {
+        lines.push(`  [step ${ev.step}] [${ev.confidence.toUpperCase()}] ${ev.tool}${formatProvenance(ev)}: ${ev.rawOutput.slice(0, 100)}`);
       }
     }
 

--- a/src/agent/SituationMemory.ts
+++ b/src/agent/SituationMemory.ts
@@ -1,5 +1,3 @@
-export type MemoryFactSource = "user" | "read_file" | "terminal" | "patch" | "test" | "model_inference";
-
 /** Runtime-observed tool evidence — always verified by definition (the tool ran). */
 export type ToolEvidence = {
   step: number;
@@ -13,14 +11,6 @@ export type ToolEvidence = {
   lineRange?: { start: number; end: number };
   exitCode?: number;
   changedFiles?: string[];
-};
-
-/** A semantic claim extracted from model text — NOT automatically verified. */
-export type SemanticClaim = {
-  text: string;
-  step: number;
-  verified: boolean;
-  evidenceRefs: string[]; // references to ToolEvidence step+tool
 };
 
 /** An unsupported assumption that must be verified before it can enter durable memory. */
@@ -41,7 +31,6 @@ export type FailureRecord = {
 
 export class SituationMemory {
   private evidence: ToolEvidence[] = [];
-  private semanticClaims: SemanticClaim[] = [];
   private pendingVerifications: PendingVerification[] = [];
   private failures = new Map<string, FailureRecord>();
   private priorActions: string[] = [];

--- a/src/agent/Verifier.ts
+++ b/src/agent/Verifier.ts
@@ -178,8 +178,15 @@ ${planningText}`;
     const response = await createResponse(client, { model, input, tools: [], toolChoice: "none", signal });
     const text = extractResponseText(response);
     const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) return { ok: true, unsupported_assumptions: [] }; // lenient on parse failure
-    const parsed = JSON.parse(jsonMatch[0]) as { unsupported_assumptions: UnsupportedAssumption[] };
+    if (!jsonMatch) {
+      return { ok: false, reason: `no JSON in intermediate audit response: ${text.slice(0, 200)}` };
+    }
+    let parsed: { unsupported_assumptions?: UnsupportedAssumption[] };
+    try {
+      parsed = JSON.parse(jsonMatch[0]);
+    } catch (parseErr) {
+      return { ok: false, reason: `JSON parse error in intermediate audit: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}` };
+    }
     return { ok: true, unsupported_assumptions: parsed.unsupported_assumptions ?? [] };
   } catch (err) {
     return { ok: false, reason: err instanceof Error ? err.message : String(err) };

--- a/src/agent/Verifier.ts
+++ b/src/agent/Verifier.ts
@@ -1,6 +1,6 @@
 import type OpenAI from "openai";
 import { createResponse } from "../api/responsesClient.js";
-import type { ToolEvidence } from "./SituationMemory.js";
+import type { ToolEvidence, PendingVerification } from "./SituationMemory.js";
 
 export type VerifierVerdict = "pass" | "fail" | "needs_more_evidence";
 
@@ -19,86 +19,109 @@ export type VerifierResult = {
   missing_evidence: string[];
   required_next_actions: string[];
   confidence: "high" | "medium" | "low";
+  /** Claims that are now resolved (backed by evidence) — used to clear pending verifications. */
+  resolved_claims?: string[];
 };
 
-const VERIFIER_PROMPT = `You are an independent evidence auditor for a coding agent runtime. Your job is to determine whether the executor's final claim is supported by concrete runtime evidence.
+const VERIFIER_SYSTEM_PROMPT = `You are an independent evidence auditor for a coding agent runtime. Your sole job is to determine whether the executor's claims are supported by concrete runtime evidence.
 
-Rules:
-- Do not trust the executor's self-assessment or language like "I verified" or "I checked".
-- Only trust the runtime evidence listed below (tool calls and their outputs).
-- Claims about file contents must be backed by read_file_range evidence.
-- Claims that tests pass must be backed by a test command with exit code 0.
-- Claims that patches were applied must be backed by apply_patch success output.
-- If a claim cannot be traced to runtime evidence, it is an unsupported assumption.
+Rules you must follow:
+1. Do NOT trust the executor's self-assessment or compliance language ("I verified", "I checked", "I confirmed").
+2. Compliance language is NOT evidence. Only tool results are evidence.
+3. Claims about file contents must be backed by a read_file_range result with file path and line range.
+4. Claims that tests pass must be backed by a run_shell result with exit code 0.
+5. Claims that patches were applied must be backed by an apply_patch result with changed file list.
+6. Claims about environment/dependency state must be backed by tool observation.
+7. If a claim cannot be traced to a concrete tool result in the evidence list, it is unsupported.
 
-Respond with a JSON object only, no other text. Use this exact schema:
+Respond with a JSON object only. No prose before or after the JSON. Use this exact schema:
 {
   "verdict": "pass" | "fail" | "needs_more_evidence",
-  "reason": "short explanation",
-  "evidence_backed_facts": ["fact backed by evidence", ...],
-  "executor_claims": ["claim made by executor", ...],
+  "reason": "one sentence",
+  "evidence_backed_facts": ["..."],
+  "executor_claims": ["..."],
   "unsupported_assumptions": [
-    {
-      "claim": "...",
-      "why_unsupported": "...",
-      "required_verification": "..."
-    }
+    { "claim": "...", "why_unsupported": "...", "required_verification": "..." }
   ],
-  "missing_evidence": ["what evidence is missing", ...],
-  "required_next_actions": ["what the agent should do next", ...],
+  "missing_evidence": ["..."],
+  "required_next_actions": ["..."],
+  "resolved_claims": ["..."],
   "confidence": "high" | "medium" | "low"
 }`;
+
+export type VerifierRunResult =
+  | { ok: true; result: VerifierResult }
+  | { ok: false; reason: string };
 
 export async function runVerifier(
   client: OpenAI,
   model: string,
   task: string,
   evidence: ToolEvidence[],
+  pendingVerifications: PendingVerification[],
   executorClaim: string,
   signal?: AbortSignal
-): Promise<VerifierResult> {
+): Promise<VerifierRunResult> {
   const evidenceText = evidence.length > 0
-    ? evidence.map((e) =>
-        `[step ${e.step}] Tool: ${e.tool}\nArgs: ${e.argsText}\nStatus: ${e.ok ? "ok" : "failed"}\nOutput:\n${e.outputExcerpt}`
-      ).join("\n---\n")
+    ? evidence.map((e) => {
+        const provenance = [
+          e.filePath ? `file=${e.filePath}` : null,
+          e.lineRange ? `lines=${e.lineRange.start}-${e.lineRange.end}` : null,
+          e.exitCode !== undefined ? `exit=${e.exitCode}` : null,
+          e.changedFiles?.length ? `changed=${e.changedFiles.join(",")}` : null
+        ].filter(Boolean).join(" ");
+        return `[step ${e.step}] Tool: ${e.tool} | Status: ${e.ok ? "ok" : "failed"}${provenance ? ` | ${provenance}` : ""}\nArgs: ${e.argsText}\nRaw output:\n${e.rawOutput}`;
+      }).join("\n---\n")
     : "No tool evidence recorded.";
 
-  const input = `${VERIFIER_PROMPT}
+  const pendingText = pendingVerifications.length > 0
+    ? "\nPreviously identified pending verifications:\n" + pendingVerifications.map(
+        (p) => `  - ${p.claim} (required: ${p.requiredAction})`
+      ).join("\n")
+    : "";
+
+  const input = `${VERIFIER_SYSTEM_PROMPT}
 
 ORIGINAL TASK:
 ${task}
 
-RUNTIME EVIDENCE:
+RUNTIME EVIDENCE (raw tool results — these are the only facts):
 ${evidenceText}
+${pendingText}
 
-EXECUTOR FINAL CLAIM (treat as unverified until you audit it):
+EXECUTOR FINAL CLAIM (treat as unverified — audit against the evidence above):
 ${executorClaim}`;
 
-  const response = await createResponse(client, {
-    model,
-    input,
-    tools: [],
-    toolChoice: "none",
-    signal
-  });
+  let lastError = "";
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const response = await createResponse(client, {
+        model,
+        input,
+        tools: [],
+        toolChoice: "none",
+        signal
+      });
 
-  const text = extractResponseText(response);
-  try {
-    const jsonMatch = text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) throw new Error("no JSON found");
-    return JSON.parse(jsonMatch[0]) as VerifierResult;
-  } catch {
-    return {
-      verdict: "needs_more_evidence",
-      reason: `Verifier returned non-JSON response: ${text.slice(0, 200)}`,
-      evidence_backed_facts: [],
-      executor_claims: [executorClaim.slice(0, 200)],
-      unsupported_assumptions: [],
-      missing_evidence: [],
-      required_next_actions: ["Re-run with explicit tool verification"],
-      confidence: "low"
-    };
+      const text = extractResponseText(response);
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) {
+        lastError = `attempt ${attempt + 1}: no JSON in response: ${text.slice(0, 200)}`;
+        continue;
+      }
+      const parsed = JSON.parse(jsonMatch[0]) as VerifierResult;
+      if (!["pass", "fail", "needs_more_evidence"].includes(parsed.verdict)) {
+        lastError = `attempt ${attempt + 1}: invalid verdict: ${parsed.verdict}`;
+        continue;
+      }
+      return { ok: true, result: parsed };
+    } catch (err) {
+      lastError = `attempt ${attempt + 1}: ${err instanceof Error ? err.message : String(err)}`;
+    }
   }
+
+  // fail closed — do not silently accept the executor's answer
+  return { ok: false, reason: `Verifier could not produce a verdict after 2 attempts. Last error: ${lastError}` };
 }
 
 function extractResponseText(response: any): string {

--- a/src/agent/Verifier.ts
+++ b/src/agent/Verifier.ts
@@ -1,0 +1,118 @@
+import type OpenAI from "openai";
+import { createResponse } from "../api/responsesClient.js";
+import type { ToolEvidence } from "./SituationMemory.js";
+
+export type VerifierVerdict = "pass" | "fail" | "needs_more_evidence";
+
+export type UnsupportedAssumption = {
+  claim: string;
+  why_unsupported: string;
+  required_verification: string;
+};
+
+export type VerifierResult = {
+  verdict: VerifierVerdict;
+  reason: string;
+  evidence_backed_facts: string[];
+  executor_claims: string[];
+  unsupported_assumptions: UnsupportedAssumption[];
+  missing_evidence: string[];
+  required_next_actions: string[];
+  confidence: "high" | "medium" | "low";
+};
+
+const VERIFIER_PROMPT = `You are an independent evidence auditor for a coding agent runtime. Your job is to determine whether the executor's final claim is supported by concrete runtime evidence.
+
+Rules:
+- Do not trust the executor's self-assessment or language like "I verified" or "I checked".
+- Only trust the runtime evidence listed below (tool calls and their outputs).
+- Claims about file contents must be backed by read_file_range evidence.
+- Claims that tests pass must be backed by a test command with exit code 0.
+- Claims that patches were applied must be backed by apply_patch success output.
+- If a claim cannot be traced to runtime evidence, it is an unsupported assumption.
+
+Respond with a JSON object only, no other text. Use this exact schema:
+{
+  "verdict": "pass" | "fail" | "needs_more_evidence",
+  "reason": "short explanation",
+  "evidence_backed_facts": ["fact backed by evidence", ...],
+  "executor_claims": ["claim made by executor", ...],
+  "unsupported_assumptions": [
+    {
+      "claim": "...",
+      "why_unsupported": "...",
+      "required_verification": "..."
+    }
+  ],
+  "missing_evidence": ["what evidence is missing", ...],
+  "required_next_actions": ["what the agent should do next", ...],
+  "confidence": "high" | "medium" | "low"
+}`;
+
+export async function runVerifier(
+  client: OpenAI,
+  model: string,
+  task: string,
+  evidence: ToolEvidence[],
+  executorClaim: string,
+  signal?: AbortSignal
+): Promise<VerifierResult> {
+  const evidenceText = evidence.length > 0
+    ? evidence.map((e) =>
+        `[step ${e.step}] Tool: ${e.tool}\nArgs: ${e.argsText}\nStatus: ${e.ok ? "ok" : "failed"}\nOutput:\n${e.outputExcerpt}`
+      ).join("\n---\n")
+    : "No tool evidence recorded.";
+
+  const input = `${VERIFIER_PROMPT}
+
+ORIGINAL TASK:
+${task}
+
+RUNTIME EVIDENCE:
+${evidenceText}
+
+EXECUTOR FINAL CLAIM (treat as unverified until you audit it):
+${executorClaim}`;
+
+  const response = await createResponse(client, {
+    model,
+    input,
+    tools: [],
+    toolChoice: "none",
+    signal
+  });
+
+  const text = extractResponseText(response);
+  try {
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) throw new Error("no JSON found");
+    return JSON.parse(jsonMatch[0]) as VerifierResult;
+  } catch {
+    return {
+      verdict: "needs_more_evidence",
+      reason: `Verifier returned non-JSON response: ${text.slice(0, 200)}`,
+      evidence_backed_facts: [],
+      executor_claims: [executorClaim.slice(0, 200)],
+      unsupported_assumptions: [],
+      missing_evidence: [],
+      required_next_actions: ["Re-run with explicit tool verification"],
+      confidence: "low"
+    };
+  }
+}
+
+function extractResponseText(response: any): string {
+  const output = Array.isArray(response?.output) ? response.output : [];
+  const parts: string[] = [];
+  for (const item of output) {
+    if (item?.type === "message" && Array.isArray(item.content)) {
+      for (const c of item.content) {
+        if (typeof c?.text === "string") parts.push(c.text);
+        if (typeof c?.output_text === "string") parts.push(c.output_text);
+      }
+    }
+    if (typeof item?.content === "string") parts.push(item.content);
+  }
+  if (typeof response?.output_text === "string") parts.push(response.output_text);
+  return parts.join("\n").trim();
+}

--- a/src/agent/Verifier.ts
+++ b/src/agent/Verifier.ts
@@ -60,6 +60,7 @@ export async function runVerifier(
   evidence: ToolEvidence[],
   pendingVerifications: PendingVerification[],
   executorClaim: string,
+  intermediateAuditFailed: boolean,
   signal?: AbortSignal
 ): Promise<VerifierRunResult> {
   const evidenceText = evidence.length > 0
@@ -89,7 +90,7 @@ RUNTIME EVIDENCE (raw tool results — these are the only facts):
 ${evidenceText}
 ${pendingText}
 
-EXECUTOR FINAL CLAIM (treat as unverified — audit against the evidence above):
+${intermediateAuditFailed ? "NOTE: One or more intermediate claim audits failed during this run. Apply extra scrutiny to all claims.\n" : ""}EXECUTOR FINAL CLAIM (treat as unverified — audit against the evidence above):
 ${executorClaim}`;
 
   let lastError = "";

--- a/src/agent/Verifier.ts
+++ b/src/agent/Verifier.ts
@@ -124,6 +124,67 @@ ${executorClaim}`;
   return { ok: false, reason: `Verifier could not produce a verdict after 2 attempts. Last error: ${lastError}` };
 }
 
+const INTERMEDIATE_AUDIT_PROMPT = `You are an independent assumption detector for a coding agent runtime. Your job is to find current-state claims in intermediate planning text that are NOT backed by the runtime evidence provided.
+
+Rules:
+1. Only identify claims about observable workspace state: file contents, test results, environment state, command output, dependency state.
+2. Do NOT flag general reasoning, algorithmic plans, or hypotheticals.
+3. Claims backed by a tool result in the evidence list are acceptable.
+4. Compliance language ("I will check", "let me verify") is intent, not a claim — do not flag it.
+5. Only flag concrete factual assertions about the current state of the workspace.
+
+Respond with JSON only. No prose. Schema:
+{
+  "unsupported_assumptions": [
+    { "claim": "...", "why_unsupported": "...", "required_verification": "..." }
+  ]
+}
+If there are no unsupported current-state claims, return: { "unsupported_assumptions": [] }`;
+
+export type IntermediateAuditResult =
+  | { ok: true; unsupported_assumptions: UnsupportedAssumption[] }
+  | { ok: false; reason: string };
+
+export async function auditIntermediateClaims(
+  client: OpenAI,
+  model: string,
+  evidence: ToolEvidence[],
+  planningText: string,
+  signal?: AbortSignal
+): Promise<IntermediateAuditResult> {
+  if (!planningText.trim()) return { ok: true, unsupported_assumptions: [] };
+
+  const evidenceText = evidence.length > 0
+    ? evidence.map((e) => {
+        const provenance = [
+          e.filePath ? `file=${e.filePath}` : null,
+          e.lineRange ? `lines=${e.lineRange.start}-${e.lineRange.end}` : null,
+          e.exitCode !== undefined ? `exit=${e.exitCode}` : null
+        ].filter(Boolean).join(" ");
+        return `[step ${e.step}] ${e.tool}${provenance ? ` (${provenance})` : ""}: ${e.rawOutput.slice(0, 200)}`;
+      }).join("\n")
+    : "No tool evidence yet.";
+
+  const input = `${INTERMEDIATE_AUDIT_PROMPT}
+
+RUNTIME EVIDENCE:
+${evidenceText}
+
+INTERMEDIATE PLANNING TEXT TO AUDIT:
+${planningText}`;
+
+  try {
+    const response = await createResponse(client, { model, input, tools: [], toolChoice: "none", signal });
+    const text = extractResponseText(response);
+    const jsonMatch = text.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) return { ok: true, unsupported_assumptions: [] }; // lenient on parse failure
+    const parsed = JSON.parse(jsonMatch[0]) as { unsupported_assumptions: UnsupportedAssumption[] };
+    return { ok: true, unsupported_assumptions: parsed.unsupported_assumptions ?? [] };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 function extractResponseText(response: any): string {
   const output = Array.isArray(response?.output) ? response.output : [];
   const parts: string[] = [];

--- a/src/agent/modelInputBuilder.ts
+++ b/src/agent/modelInputBuilder.ts
@@ -10,6 +10,7 @@ export type ModelInputBuildOptions = {
   generalSkills: Skill[];
   toolSkills: ToolSkill[];
   projectInstructions: string;
+  situationSnapshot?: string;
 };
 
 export function buildModelInput(options: ModelInputBuildOptions): string {
@@ -44,7 +45,11 @@ ${options.projectInstructions || "None."}
 <Relevant Context>
 ${relevant || "No additional context yet."}
 </Relevant Context>
-
+${options.situationSnapshot ? `
+<Situation Memory>
+${options.situationSnapshot}
+</Situation Memory>
+` : ""}
 <User Task>
 ${options.task}
 </User Task>`;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ type CliOpts = {
   webSearch?: boolean;
   xSearch?: boolean;
   conversationMode?: ConversationMode;
+  verifier?: boolean;
 };
 
 let activeSigintCleanup: (() => void) | undefined;
@@ -38,7 +39,8 @@ export async function main(): Promise<void> {
     .option("--no-server-tools", "Disable xAI server-side tools")
     .option("--no-web-search", "Disable xAI web_search server-side tool")
     .option("--no-x-search", "Disable xAI x_search server-side tool")
-    .option("--conversation-mode <mode>", "stateful|stateless|hybrid (default: stateful)", "stateful");
+    .option("--conversation-mode <mode>", "stateful|stateless|hybrid (default: stateful)", "stateful")
+    .option("--verifier", "Enable independent verifier call to audit executor claims");
 
   program.command("ask <question...>").description("Ask a question").action(async (question: string[]) => runOne(question.join(" "), program.opts<CliOpts>(), "ask"));
   program.command("edit <task...>").description("Run an edit task").action(async (task: string[]) => runOne(task.join(" "), program.opts<CliOpts>(), "edit"));
@@ -71,7 +73,8 @@ async function makeAgent(opts: CliOpts, task = "", cwd = process.cwd()): Promise
     serverTools: toolOverrides.serverTools,
     enableWebSearch: toolOverrides.enableWebSearch,
     enableXSearch: toolOverrides.enableXSearch,
-    conversationMode: parseConversationMode(opts.conversationMode)
+    conversationMode: parseConversationMode(opts.conversationMode),
+    enableVerifier: opts.verifier === true
   });
   const client = createXaiClient();
   const agent = new Agent(client, config, task);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ type CliOpts = {
   xSearch?: boolean;
   conversationMode?: ConversationMode;
   verifier?: boolean;
+  verifierModel?: string;
 };
 
 let activeSigintCleanup: (() => void) | undefined;
@@ -40,7 +41,8 @@ export async function main(): Promise<void> {
     .option("--no-web-search", "Disable xAI web_search server-side tool")
     .option("--no-x-search", "Disable xAI x_search server-side tool")
     .option("--conversation-mode <mode>", "stateful|stateless|hybrid (default: stateful)", "stateful")
-    .option("--verifier", "Enable independent verifier call to audit executor claims");
+    .option("--verifier", "Enable independent verifier call to audit executor claims")
+    .option("--verifier-model <model>", "Model to use for the verifier (default: same as executor model)");
 
   program.command("ask <question...>").description("Ask a question").action(async (question: string[]) => runOne(question.join(" "), program.opts<CliOpts>(), "ask"));
   program.command("edit <task...>").description("Run an edit task").action(async (task: string[]) => runOne(task.join(" "), program.opts<CliOpts>(), "edit"));
@@ -74,7 +76,8 @@ async function makeAgent(opts: CliOpts, task = "", cwd = process.cwd()): Promise
     enableWebSearch: toolOverrides.enableWebSearch,
     enableXSearch: toolOverrides.enableXSearch,
     conversationMode: parseConversationMode(opts.conversationMode),
-    enableVerifier: opts.verifier === true
+    enableVerifier: opts.verifier === true,
+    verifierModel: opts.verifierModel
   });
   const client = createXaiClient();
   const agent = new Agent(client, config, task);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { Command } from "commander";
 import { createXaiClient } from "./api/xaiClient.js";
 import { Agent } from "./agent/Agent.js";
-import { loadConfig, type ApprovalMode, type SandboxProfile, type ToolChoice } from "./config/loadConfig.js";
+import { loadConfig, type ApprovalMode, type SandboxProfile, type ToolChoice, type ConversationMode } from "./config/loadConfig.js";
 import { startRepl } from "./ui/repl.js";
 import { formatSessionStatus, printHeader } from "./ui/terminal.js";
 import { SessionStore } from "./session/SessionStore.js";
@@ -19,6 +19,7 @@ type CliOpts = {
   serverTools?: boolean;
   webSearch?: boolean;
   xSearch?: boolean;
+  conversationMode?: ConversationMode;
 };
 
 let activeSigintCleanup: (() => void) | undefined;
@@ -36,7 +37,8 @@ export async function main(): Promise<void> {
     .option("--max-steps <number>", "Maximum agent steps", "30")
     .option("--no-server-tools", "Disable xAI server-side tools")
     .option("--no-web-search", "Disable xAI web_search server-side tool")
-    .option("--no-x-search", "Disable xAI x_search server-side tool");
+    .option("--no-x-search", "Disable xAI x_search server-side tool")
+    .option("--conversation-mode <mode>", "stateful|stateless|hybrid (default: stateful)", "stateful");
 
   program.command("ask <question...>").description("Ask a question").action(async (question: string[]) => runOne(question.join(" "), program.opts<CliOpts>(), "ask"));
   program.command("edit <task...>").description("Run an edit task").action(async (task: string[]) => runOne(task.join(" "), program.opts<CliOpts>(), "edit"));
@@ -68,7 +70,8 @@ async function makeAgent(opts: CliOpts, task = "", cwd = process.cwd()): Promise
     maxSteps: parseMaxSteps(opts.maxSteps),
     serverTools: toolOverrides.serverTools,
     enableWebSearch: toolOverrides.enableWebSearch,
-    enableXSearch: toolOverrides.enableXSearch
+    enableXSearch: toolOverrides.enableXSearch,
+    conversationMode: parseConversationMode(opts.conversationMode)
   });
   const client = createXaiClient();
   const agent = new Agent(client, config, task);
@@ -112,6 +115,15 @@ export function parseSandboxProfile(value?: string): SandboxProfile | undefined 
     throw new Error(`--profile must be one of: ${profiles.join(", ")}`);
   }
   return value as SandboxProfile;
+}
+
+export function parseConversationMode(value?: string): ConversationMode | undefined {
+  if (value === undefined) return undefined;
+  const modes: ConversationMode[] = ["stateful", "stateless", "hybrid"];
+  if (!modes.includes(value as ConversationMode)) {
+    throw new Error(`--conversation-mode must be one of: ${modes.join(", ")}`);
+  }
+  return value as ConversationMode;
 }
 
 async function runOne(task: string, opts: CliOpts, _kind: string): Promise<void> {

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -22,6 +22,7 @@ export type GrokCodeConfig = {
   hybridResetAfterSteps: number;
   hybridResetAfterFailures: number;
   enableVerifier: boolean;
+  verifierModel: string;
 };
 
 export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfig> = {}): GrokCodeConfig {
@@ -43,6 +44,7 @@ export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfi
     hybridResetAfterSteps: 10,
     hybridResetAfterFailures: 3,
     enableVerifier: false,
+    verifierModel: "grok-4.3",
     ...projectConfig,
     ...cleanOverrides
   };

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -21,6 +21,7 @@ export type GrokCodeConfig = {
   conversationMode: ConversationMode;
   hybridResetAfterSteps: number;
   hybridResetAfterFailures: number;
+  enableVerifier: boolean;
 };
 
 export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfig> = {}): GrokCodeConfig {
@@ -41,6 +42,7 @@ export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfi
     conversationMode: "stateful",
     hybridResetAfterSteps: 10,
     hybridResetAfterFailures: 3,
+    enableVerifier: false,
     ...projectConfig,
     ...cleanOverrides
   };

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -5,6 +5,7 @@ import dotenv from "dotenv";
 export type ApprovalMode = "on-request" | "auto-local" | "auto-safe" | "auto-all" | "never";
 export type ToolChoice = "auto" | "required" | "none";
 export type SandboxProfile = "default" | "build" | "test" | "debug" | "package" | "docs";
+export type ConversationMode = "stateful" | "stateless" | "hybrid";
 
 export type GrokCodeConfig = {
   model: string;
@@ -17,6 +18,9 @@ export type GrokCodeConfig = {
   workspaceRoot: string;
   sandboxProfile: SandboxProfile;
   workspaceTrusted: boolean;
+  conversationMode: ConversationMode;
+  hybridResetAfterSteps: number;
+  hybridResetAfterFailures: number;
 };
 
 export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfig> = {}): GrokCodeConfig {
@@ -34,6 +38,9 @@ export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfi
     workspaceRoot: cwd,
     sandboxProfile: "default",
     workspaceTrusted: false,
+    conversationMode: "stateful",
+    hybridResetAfterSteps: 10,
+    hybridResetAfterFailures: 3,
     ...projectConfig,
     ...cleanOverrides
   };

--- a/src/config/loadConfig.ts
+++ b/src/config/loadConfig.ts
@@ -23,6 +23,7 @@ export type GrokCodeConfig = {
   hybridResetAfterFailures: number;
   enableVerifier: boolean;
   verifierModel: string;
+  maxVerifierReprompts: number;
 };
 
 export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfig> = {}): GrokCodeConfig {
@@ -45,6 +46,7 @@ export function loadConfig(cwd = process.cwd(), overrides: Partial<GrokCodeConfi
     hybridResetAfterFailures: 3,
     enableVerifier: false,
     verifierModel: "grok-4.3",
+    maxVerifierReprompts: 2,
     ...projectConfig,
     ...cleanOverrides
   };

--- a/tests/agentLoop.test.mjs
+++ b/tests/agentLoop.test.mjs
@@ -1,0 +1,244 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { AgentLoop, shouldContinueAfterPlanOnlyResponse } from "../dist/agent/AgentLoop.js";
+
+// --- response shape helpers ---
+
+function toolCallResp(name, callId, args = "{}") {
+  return { id: `r-${callId}`, output: [{ type: "function_call", name, call_id: callId, arguments: args }] };
+}
+
+function multiToolResp(...calls) {
+  return {
+    id: "r-multi",
+    output: calls.map(([name, callId, args]) => ({
+      type: "function_call", name, call_id: callId, arguments: args ?? "{}"
+    }))
+  };
+}
+
+function textResp(text) {
+  return { id: "r-text", output: [{ type: "message", content: [{ text }] }] };
+}
+
+function emptyResp() {
+  return { id: "r-empty", output: [] };
+}
+
+// --- mock infrastructure ---
+
+function makeSeqClient(sequence) {
+  let i = 0;
+  const calls = [];
+  return {
+    calls,
+    api: {
+      responses: {
+        create: async (payload) => {
+          calls.push(payload);
+          return sequence[Math.min(i++, sequence.length - 1)];
+        }
+      }
+    }
+  };
+}
+
+function makeBackground() {
+  return { listRunning: () => [], stopAll: async () => [], list: () => [] };
+}
+
+function makeTools(execFn) {
+  return {
+    schemas: () => [],
+    isReadOnly: () => false,
+    execute: execFn ?? (async () => ({ ok: true, data: {}, summary: "ok" }))
+  };
+}
+
+function makeContext() {
+  return { upsert: () => {}, nextStep: () => {}, add: () => {}, relevant: () => [] };
+}
+
+function makeConfig(overrides = {}) {
+  return {
+    model: "test-model",
+    approval: "never",
+    toolChoice: "auto",
+    maxSteps: 10,
+    serverTools: false,
+    enableWebSearch: false,
+    enableXSearch: false,
+    workspaceRoot: "/tmp",
+    sandboxProfile: "default",
+    workspaceTrusted: false,
+    conversationMode: "stateless",
+    hybridResetAfterSteps: 10,
+    hybridResetAfterFailures: 3,
+    enableVerifier: false,
+    verifierModel: "test-model",
+    maxVerifierReprompts: 2,
+    ...overrides
+  };
+}
+
+function makeLoop(mock, configOverrides = {}, toolExecFn) {
+  const bg = makeBackground();
+  const toolCtx = { background: bg, sandbox: null };
+  const skillLoader = { select: () => [] };
+  const toolSkills = { toolIndex: () => "", select: () => [] };
+  return new AgentLoop(
+    mock.api,
+    makeConfig(configOverrides),
+    makeContext(),
+    makeTools(toolExecFn),
+    toolCtx,
+    skillLoader,
+    toolSkills,
+    ""
+  );
+}
+
+// --- shouldContinueAfterPlanOnlyResponse unit tests ---
+
+test("shouldContinueAfterPlanOnlyResponse: true for intent on action task with no prior actions", () => {
+  assert.equal(
+    shouldContinueAfterPlanOnlyResponse("I'll now call the tool to fix this.", "fix the bug in main.ts", 0),
+    true
+  );
+});
+
+test("shouldContinueAfterPlanOnlyResponse: false when actions already taken", () => {
+  assert.equal(
+    shouldContinueAfterPlanOnlyResponse("I'll now call the tool to fix this.", "fix the bug in main.ts", 1),
+    false
+  );
+});
+
+test("shouldContinueAfterPlanOnlyResponse: false for non-action task", () => {
+  assert.equal(
+    shouldContinueAfterPlanOnlyResponse("I'll now use a tool to demonstrate.", "explain how closures work", 0),
+    false
+  );
+});
+
+test("shouldContinueAfterPlanOnlyResponse: false for empty text", () => {
+  assert.equal(shouldContinueAfterPlanOnlyResponse("", "fix the bug", 0), false);
+});
+
+// --- AgentLoop integration tests ---
+
+test("stateless mode never sends previous_response_id", async () => {
+  const mock = makeSeqClient([
+    toolCallResp("run_shell", "c1", '{"command":"echo hi","reason":"test"}'),
+    textResp("Done.")
+  ]);
+  const loop = makeLoop(mock, { conversationMode: "stateless" });
+  await loop.run("run echo hi", false);
+  for (let i = 0; i < mock.calls.length; i++) {
+    assert.equal(
+      mock.calls[i].previous_response_id,
+      undefined,
+      `Call ${i} must not have previous_response_id in stateless mode`
+    );
+  }
+});
+
+test("multi-tool non-final responses are rejected with one-tool correction", async () => {
+  const mock = makeSeqClient([
+    multiToolResp(
+      ["run_shell", "c1", '{"command":"ls","reason":"a"}'],
+      ["run_shell", "c2", '{"command":"pwd","reason":"b"}']
+    ),
+    toolCallResp("run_shell", "c3", '{"command":"ls","reason":"ok"}'),
+    textResp("Done.")
+  ]);
+  const loop = makeLoop(mock);
+  await loop.run("list files", false);
+
+  assert.ok(mock.calls.length >= 2, "Should make at least 2 API calls");
+  const correctionInput = mock.calls[1]?.input ?? "";
+  assert.ok(
+    typeof correctionInput === "string" && correctionInput.includes("exactly one tool call"),
+    `Expected 'exactly one tool call' in correction, got: ${String(correctionInput).slice(0, 300)}`
+  );
+});
+
+test("narrated intent fails closed after reprompt budget is exhausted", async () => {
+  const intentText = "I'll now call the tool to fix this.";
+  // Always return intent-only text; loop must stop rather than accept it
+  const mock = makeSeqClient([textResp(intentText)]);
+  const loop = makeLoop(mock, { conversationMode: "stateless", maxSteps: 10 });
+  const result = await loop.run("fix the bug in main.ts", false);
+  assert.ok(
+    result.includes("[agent stopped:"),
+    `Expected stopped message, got: ${result.slice(0, 300)}`
+  );
+});
+
+test("empty response retries once then stops gracefully", async () => {
+  const mock = makeSeqClient([emptyResp()]);
+  const loop = makeLoop(mock);
+  const result = await loop.run("do something", false);
+  assert.equal(mock.calls.length, 2, "Should call API twice (initial + one retry)");
+  assert.ok(
+    result.includes("[agent stopped: repeated empty responses"),
+    `Got: ${result.slice(0, 300)}`
+  );
+});
+
+test("same failed tool+args is blocked on blind retry", async () => {
+  const failArgs = '{"command":"npm test","reason":"run tests"}';
+  const mock = makeSeqClient([
+    toolCallResp("run_shell", "c1", failArgs),          // step 1 — tool fails
+    toolCallResp("run_shell", "c2", failArgs),          // step 2 — blind retry → blocked
+    toolCallResp("run_shell", "c3", '{"command":"npm test --force","reason":"retry"}'),
+    textResp("Done.")
+  ]);
+  const toolExec = async (_name, args) => {
+    if (args.command === "npm test") return { ok: false, error: { message: "exit 1" } };
+    return { ok: true, data: {}, summary: "ok" };
+  };
+  const loop = makeLoop(mock, {}, toolExec);
+  await loop.run("run tests", false);
+
+  // The 3rd API call (after blind retry block) must contain the correction
+  const correctionInput = mock.calls[2]?.input ?? "";
+  assert.ok(
+    typeof correctionInput === "string" && correctionInput.includes("BLIND RETRY BLOCKED"),
+    `Expected BLIND RETRY BLOCKED in 3rd call, got: ${String(correctionInput).slice(0, 300)}`
+  );
+});
+
+test("failure context is injected into next prompt after tool failure", async () => {
+  const mock = makeSeqClient([
+    toolCallResp("run_shell", "c1", '{"command":"fail-cmd","reason":"test"}'),
+    textResp("I see the previous command failed, I'll take a different approach.")
+  ]);
+  const toolExec = async () => ({ ok: false, error: { message: "command not found" } });
+  const loop = makeLoop(mock, { conversationMode: "stateless" }, toolExec);
+  await loop.run("run command", false);
+
+  // Step 2 prompt is rebuilt from snapshot — must include failure warning
+  const step2Input = mock.calls[1]?.input ?? "";
+  assert.ok(
+    typeof step2Input === "string" && step2Input.includes("MUST NOT repeat blindly"),
+    `Expected failure context in step 2 prompt, got: ${String(step2Input).slice(0, 400)}`
+  );
+});
+
+test("memory facts include provenance and confidence labels in prompt", async () => {
+  const mock = makeSeqClient([
+    toolCallResp("read_file_range", "c1", '{"path":"src/foo.ts","start":1,"end":10}'),
+    textResp("The file contains the fix.")
+  ]);
+  const toolExec = async () => ({ ok: true, data: { content: "export const x = 1;" }, summary: "read ok" });
+  const loop = makeLoop(mock, { conversationMode: "stateless" }, toolExec);
+  await loop.run("read the file", false);
+
+  // Step 2 prompt includes snapshot with [VERIFIED] label
+  const step2Input = mock.calls[1]?.input ?? "";
+  assert.ok(
+    typeof step2Input === "string" && step2Input.includes("[VERIFIED]"),
+    `Expected [VERIFIED] confidence label in prompt, got: ${String(step2Input).slice(0, 400)}`
+  );
+});

--- a/tests/situationMemory.test.mjs
+++ b/tests/situationMemory.test.mjs
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SituationMemory } from "../dist/agent/SituationMemory.js";
+
+test("recordEvidence sets confidence:verified when ok=true", () => {
+  const mem = new SituationMemory();
+  mem.recordEvidence("read_file_range", { path: "a.ts", start: 1, end: 10 }, "content here", true, 1);
+  const evidence = mem.getEvidence();
+  assert.equal(evidence.length, 1);
+  assert.equal(evidence[0].confidence, "verified");
+  assert.equal(evidence[0].ok, true);
+});
+
+test("recordEvidence sets confidence:uncertain when ok=false", () => {
+  const mem = new SituationMemory();
+  mem.recordEvidence("run_shell", { command: "npm test" }, "ERROR: exit 1", false, 1);
+  const evidence = mem.getEvidence();
+  assert.equal(evidence.length, 1);
+  assert.equal(evidence[0].confidence, "uncertain");
+  assert.equal(evidence[0].ok, false);
+});
+
+test("snapshot labels verified evidence with [VERIFIED]", () => {
+  const mem = new SituationMemory();
+  mem.recordEvidence("run_shell", { command: "echo hi" }, "hi", true, 1);
+  const snap = mem.snapshot();
+  assert.ok(snap.includes("[VERIFIED]"), `Expected [VERIFIED] in snapshot:\n${snap}`);
+});
+
+test("snapshot labels failed evidence with [UNCERTAIN]", () => {
+  const mem = new SituationMemory();
+  mem.recordEvidence("run_shell", { command: "fail" }, "ERROR: not found", false, 1);
+  const snap = mem.snapshot();
+  assert.ok(snap.includes("[UNCERTAIN]"), `Expected [UNCERTAIN] in snapshot:\n${snap}`);
+});
+
+test("snapshot separates verified from failed observations", () => {
+  const mem = new SituationMemory();
+  mem.recordEvidence("read_file_range", { path: "a.ts", start: 1, end: 5 }, "code", true, 1);
+  mem.recordEvidence("run_shell", { command: "npm test" }, "ERROR: exit 1", false, 2);
+  const snap = mem.snapshot();
+  assert.ok(snap.includes("Verified runtime observations"), `Missing verified section:\n${snap}`);
+  assert.ok(snap.includes("Failed/uncertain observations"), `Missing uncertain section:\n${snap}`);
+});
+
+test("hasRecentlyFailed blocks same tool+args", () => {
+  const mem = new SituationMemory();
+  mem.recordFailure("run_shell", { command: "npm test" }, "exit 1", 1);
+  const record = mem.hasRecentlyFailed("run_shell", { command: "npm test" });
+  assert.ok(record, "Expected failure record to be found");
+  assert.equal(record.tool, "run_shell");
+  assert.equal(record.attempts, 1);
+});
+
+test("hasRecentlyFailed normalizes argument key order (stable key)", () => {
+  const mem = new SituationMemory();
+  // Record failure with keys in one order
+  mem.recordFailure("run_shell", { reason: "test", command: "npm test" }, "exit 1", 1);
+  // Look up with keys in different order — should still match
+  const record = mem.hasRecentlyFailed("run_shell", { command: "npm test", reason: "test" });
+  assert.ok(record, "Expected failure record regardless of key order");
+});
+
+test("hasRecentlyFailed returns undefined for different args", () => {
+  const mem = new SituationMemory();
+  mem.recordFailure("run_shell", { command: "npm test" }, "exit 1", 1);
+  const record = mem.hasRecentlyFailed("run_shell", { command: "npm build" });
+  assert.equal(record, undefined);
+});
+
+test("pending verifications are resolved by claim string", () => {
+  const mem = new SituationMemory();
+  mem.addPendingVerification("tests pass", "run_shell with exit 0", 1);
+  assert.equal(mem.getUnresolvedVerifications().length, 1);
+  mem.resolvePendingVerifications(["tests pass"]);
+  assert.equal(mem.getUnresolvedVerifications().length, 0);
+});
+
+test("duplicate pending verifications are not added twice", () => {
+  const mem = new SituationMemory();
+  mem.addPendingVerification("file exists", "read_file_range", 1);
+  mem.addPendingVerification("file exists", "read_file_range", 2);
+  assert.equal(mem.getUnresolvedVerifications().length, 1);
+});
+
+test("audit failure counter increments and is reflected in snapshot", () => {
+  const mem = new SituationMemory();
+  assert.equal(mem.hasAuditFailures(), false);
+  mem.recordAuditFailure();
+  assert.equal(mem.hasAuditFailures(), true);
+  const snap = mem.snapshot();
+  assert.ok(snap.includes("intermediate claim audit"), `Expected audit warning:\n${snap.slice(0, 400)}`);
+});
+
+test("evidence provenance: read_file_range records filePath and lineRange", () => {
+  const mem = new SituationMemory();
+  mem.recordEvidence("read_file_range", { path: "src/foo.ts", start: 10, end: 20 }, "code", true, 1);
+  const ev = mem.getEvidence()[0];
+  assert.equal(ev.filePath, "src/foo.ts");
+  assert.deepEqual(ev.lineRange, { start: 10, end: 20 });
+});
+
+test("evidence provenance: run_shell records exitCode", () => {
+  const mem = new SituationMemory();
+  mem.recordEvidence("run_shell", { command: "npm test" }, "exit_code: 0", true, 1);
+  const ev = mem.getEvidence()[0];
+  assert.equal(ev.exitCode, 0);
+});


### PR DESCRIPTION
Partially addresses #43

## Summary

- Adds `ConversationMode` type (`stateful` | `stateless` | `hybrid`) to config and `--conversation-mode` CLI flag
- Introduces `SituationMemory` with evidence-linked observations: each tool result is recorded with tool name, args, output excerpt, and step — only runtime-observed facts enter verified memory. Snapshot declares current-state-unknown stance from the first call.
- **Stateless mode**: fresh single-turn call each step, no `previous_response_id`, situation snapshot injected into every prompt
- **Hybrid mode**: starts stateful, resets after N steps or N failures; first call correctly stateful (bug fixed from v1)
- **Independent Verifier** (`--verifier`): separate stateless model call audits executor final claims against concrete runtime evidence before accepting the answer. Returns structured verdict with unsupported assumptions and required next actions.
- **Watchdog**, **narration guard**, **blind-retry guard** as before

## Bug fixes (from PR review)

- Removed dead `usesPreviousResponseId` if/else with identical branches
- Fixed hybrid first-call: now correctly stateful, not stateless
- Fixed stateless tool outputs: no longer passes raw `function_call_output` protocol items; results flow via SituationMemory snapshot
- SituationMemory now records `ToolEvidence` with concrete provenance, not just summaries

## New files

- `src/agent/Verifier.ts` — independent verifier as stateless model call
- `src/agent/SituationMemory.ts` — rewritten with evidence-linked facts and epistemic constraints

## What remains for #43 to be fully closed

- [ ] Pending-verification task queue (unsupported assumptions queued for follow-up, not silently dropped)
- [ ] Verifier model override config per project

## Test plan

- [ ] `--conversation-mode stateless` — no `previous_response_id`, snapshot visible
- [ ] `--conversation-mode hybrid` — first call stateful, reset after threshold
- [ ] `--verifier` — verifier fires before final answer, unsupported claims trigger correction
- [ ] Blind-retry guard fires on repeated same tool+args failure
- [ ] Watchdog retries then stops on empty response

🤖 Generated with [Claude Code](https://claude.com/claude-code)