### PR TITLE
[codex] Structure stateless situation memory

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -159,9 +159,13 @@ export class AgentLoop {
         }
         stepInput = buildStatelessInput({
           task,
-          verifiedObservations: toolActionSummaries.map(
+          verifiedFacts: toolActionSummaries.map(
             (s) => `${s.name} ${s.ok ? "succeeded" : "failed"}: ${s.summary}`
           ),
+          priorActions: toolActionSummaries.map(
+            (s) => `step ${s.step}: ${s.name}(${s.args ?? ""}) -> ${s.ok ? "ok" : "failed"}`
+          ),
+          inferredFacts: buildStatelessInferences(this.context.relevant(task, 20_000)),
           lastFailure: failureTracker.lastFailure(),
           verifierFeedback: lastVerifierFeedback,
           runtimeFeedback,
@@ -508,6 +512,13 @@ function buildVerifierMemoryFacts(items: ContextItem[]): EvidenceMemoryFact[] {
       factConfidence: item.factConfidence ?? "uncertain",
       source: item.source
     }));
+}
+
+function buildStatelessInferences(items: ContextItem[]): string[] {
+  return items
+    .filter((item) => item.factConfidence === "inferred" || item.factSource === "model_inference")
+    .slice(-10)
+    .map((item) => `${item.type}: ${oneLine(item.content, 300)}`);
 }
 
 function oneLine(value: string, max: number): string {

--- a/src/agent/modelInputBuilder.ts
+++ b/src/agent/modelInputBuilder.ts
@@ -14,7 +14,9 @@ export type ModelInputBuildOptions = {
 
 export type StatelessInputBuildOptions = {
   task: string;
-  verifiedObservations: string[];
+  verifiedFacts: string[];
+  priorActions: string[];
+  inferredFacts?: string[];
   lastFailure?: {
     toolName: string;
     args: string;
@@ -30,9 +32,15 @@ export type StatelessInputBuildOptions = {
 };
 
 export function buildStatelessInput(options: StatelessInputBuildOptions): string {
-  const observations = options.verifiedObservations.length > 0
-    ? options.verifiedObservations.map((o) => `- ${o}`).join("\n")
+  const verifiedFacts = options.verifiedFacts.length > 0
+    ? options.verifiedFacts.map((o) => `- ${o}`).join("\n")
     : "None yet.";
+  const priorActions = options.priorActions.length > 0
+    ? options.priorActions.map((o) => `- ${o}`).join("\n")
+    : "None yet.";
+  const inferredFacts = options.inferredFacts && options.inferredFacts.length > 0
+    ? options.inferredFacts.map((o) => `- ${o}`).join("\n")
+    : "None recorded.";
 
   const failureSection = options.lastFailure
     ? `\n<Last Failure>
@@ -82,9 +90,19 @@ ${options.projectInstructions || "None."}
 ${options.task}
 </Current Task>
 
-<Verified Workspace Observations>
-${observations}
-</Verified Workspace Observations>
+<Situation Memory>
+Current user request:
+${options.task}
+
+Verified workspace / runtime observations:
+${verifiedFacts}
+
+Prior local agent actions:
+${priorActions}
+
+Model inferences / hypotheses, not verified facts:
+${inferredFacts}
+</Situation Memory>
 ${failureSection}${verifierSection}${runtimeFeedbackSection}`;
 }
 

--- a/tests/agentLoop.test.mjs
+++ b/tests/agentLoop.test.mjs
@@ -119,6 +119,43 @@ test("stateless plan-only reprompt is injected into the next stateless prompt", 
   assert.match(String(payloads[1].input), /<Runtime Feedback>/);
 });
 
+test("stateless prompt separates verified facts, prior actions, and inferences", async () => {
+  const { loop, payloads } = makeLoop({
+    config: { conversationMode: "stateless" },
+    contextItems: [
+      {
+        type: "task_summary",
+        content: "Likely needs parser changes.",
+        priority: 60,
+        factSource: "model_inference",
+        factConfidence: "inferred",
+        tokensEstimate: 10
+      }
+    ],
+    responses: [
+      responseWithTool("r1", functionCall("read_file_range", { path: "src/parser.ts", startLine: 1, endLine: 20 }, "c1")),
+      responseWithText("r2", "done")
+    ],
+    isReadOnly(name) {
+      return name === "read_file_range";
+    },
+    execute(name, args) {
+      return { ok: true, data: {}, summary: `${name} ${args.path}` };
+    }
+  });
+
+  await loop.run("inspect parser", true);
+
+  const secondInput = String(payloads[1].input);
+  assert.match(secondInput, /<Situation Memory>/);
+  assert.match(secondInput, /Verified workspace \/ runtime observations:/);
+  assert.match(secondInput, /read_file_range succeeded: read_file_range src\/parser\.ts/);
+  assert.match(secondInput, /Prior local agent actions:/);
+  assert.match(secondInput, /step 1: read_file_range/);
+  assert.match(secondInput, /Model inferences \/ hypotheses, not verified facts:/);
+  assert.match(secondInput, /Likely needs parser changes/);
+});
+
 test("failed shell verification command can rerun after a successful patch", async () => {
   const { loop, toolCalls } = makeLoop({
     responses: [


### PR DESCRIPTION
## Summary

- Split stateless prompt memory into explicit verified observations, prior local agent actions, and model inferences.
- Preserve current failure, verifier, and runtime feedback sections while making the situation snapshot less ambiguous.
- Add coverage that stateless prompts distinguish runtime observations from hypotheses.

## Validation

- `npm test`

Part of #43.