### PR TITLE
[codex] Reset hybrid chain after invalid responses

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -121,6 +121,7 @@ export class AgentLoop {
     const failureTracker = new FailureTracker();
     let chainLength = 0;
     let consecutiveFailures = 0;
+    let invalidResponses = 0;
 
     this.context.upsert("user-task", { type: "user_task", content: task, priority: 100, pinned: true });
 
@@ -142,9 +143,10 @@ export class AgentLoop {
 
       const shouldResetChain =
         mode === "hybrid" &&
-        step > 1 &&
-        (chainLength >= this.config.hybridResetAfterTurns ||
-          consecutiveFailures >= this.config.hybridResetAfterFailures);
+          step > 1 &&
+          (chainLength >= this.config.hybridResetAfterTurns ||
+          consecutiveFailures >= this.config.hybridResetAfterFailures ||
+          invalidResponses > 0);
 
       let stepInput: any;
       let stepPreviousResponseId: string | undefined;
@@ -155,6 +157,7 @@ export class AgentLoop {
             `[Hybrid] Resetting conversation chain at step ${step} (turns=${chainLength}, consecutive failures=${consecutiveFailures})`
           );
           chainLength = 0;
+          invalidResponses = 0;
           previousResponseId = undefined;
         }
         stepInput = buildStatelessInput({
@@ -206,6 +209,7 @@ export class AgentLoop {
           console.log("[Warning] Empty response from model. Requesting continuation.");
           runtimeFeedback =
             "Your previous response was empty. Continue by emitting exactly one tool call or a final answer. Do not respond with only narration.";
+          invalidResponses++;
           pendingInput = runtimeFeedback;
           step++;
           continue;
@@ -229,6 +233,7 @@ export class AgentLoop {
           );
           runtimeFeedback =
             "You provided a plan but did not request any function_call tools. The user asked for an action, not only a plan. Continue now by requesting exactly one appropriate tool in this response. If the action cannot be completed, explain the concrete blocker after using any relevant inspection tools.";
+          invalidResponses++;
           pendingInput = runtimeFeedback;
           step++;
           continue;
@@ -289,6 +294,7 @@ export class AgentLoop {
         runtimeFeedback =
           `Invalid response: requested ${parsed.functionCalls.length} tool calls in one turn. ` +
           "Continue by requesting exactly one tool call, or provide a final answer if the task is complete.";
+        invalidResponses++;
         pendingInput = runtimeFeedback;
         step++;
         continue;
@@ -318,6 +324,7 @@ export class AgentLoop {
         pendingInput = outputs;
       }
       runtimeFeedback = undefined;
+      invalidResponses = 0;
 
       step++;
     }

--- a/tests/agentLoop.test.mjs
+++ b/tests/agentLoop.test.mjs
@@ -162,6 +162,22 @@ test("multiple tool calls are rejected and corrected before execution", async ()
   assert.match(String(payloads[1].input), /exactly one tool call/);
 });
 
+test("hybrid resets conversation after invalid plan-only response", async () => {
+  const { loop, payloads } = makeLoop({
+    config: { conversationMode: "hybrid" },
+    responses: [
+      responseWithText("r1", "I will now use tools to inspect it."),
+      responseWithText("r2", "done")
+    ]
+  });
+
+  await loop.run("fix bug", true);
+
+  assert.equal(payloads[1].previous_response_id, undefined);
+  assert.match(String(payloads[1].input), /<Current Task>/);
+  assert.match(String(payloads[1].input), /<Runtime Feedback>/);
+});
+
 test("verifier audits zero-tool final answers and reports retry exhaustion", async () => {
   const { loop, payloads } = makeLoop({
     config: { enableVerifier: true, verifierMaxRetries: 1 },


### PR DESCRIPTION
## Summary

- Track empty, plan-only, and multi-tool invalid responses as invalid-response events.
- In hybrid mode, reset the conversation chain after those events so the corrective retry is a fresh stateless call.
- Add coverage that hybrid correction clears `previous_response_id` and injects runtime feedback.

## Validation

- `npm test`

Part of #43.