### PR TITLE
[codex] Guard repeated failures for all tools

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -402,20 +402,11 @@ export class AgentLoop {
   ): Promise<{ type: "function_call_output"; call_id: string; output: string }> {
     throwIfAborted(signal);
     usedToolNames.add(call.name);
+    const rawArgs = call.arguments ?? "{}";
 
-    let args: unknown;
-    try {
-      args = JSON.parse(call.arguments || "{}");
-    } catch (error) {
-      const result = {
-        ok: false,
-        error: { code: "json_parse_error", message: error instanceof Error ? error.message : String(error) }
-      };
-      return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
-    }
-
-    // Repeated failure guard: block non-read-only tools that have already failed with the same args
-    if (!this.tools.isReadOnly(call.name) && failureTracker.isRepeated(call.name, call.arguments ?? "{}")) {
+    // Repeated failure guard: block exact repeats of any tool call that failed
+    // without intervening progress, including read-only inspection calls.
+    if (failureTracker.isRepeated(call.name, rawArgs)) {
       const prior = failureTracker.lastFailure();
       const result = {
         ok: false,
@@ -427,7 +418,20 @@ export class AgentLoop {
             `. Choose a different approach: narrow the scope, inspect the root cause, or change strategy.`
         }
       };
-      toolActionSummaries.push({ step, name: call.name, ok: false, summary: result.error.message, args: call.arguments?.slice(0, 300) });
+      toolActionSummaries.push({ step, name: call.name, ok: false, summary: `${result.error.code}: ${result.error.message}`, args: call.arguments?.slice(0, 300) });
+      return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
+    }
+
+    let args: unknown;
+    try {
+      args = JSON.parse(rawArgs);
+    } catch (error) {
+      const result = {
+        ok: false,
+        error: { code: "json_parse_error", message: error instanceof Error ? error.message : String(error) }
+      };
+      failureTracker.record(call.name, rawArgs, result.error.message);
+      toolActionSummaries.push({ step, name: call.name, ok: false, summary: `${result.error.code}: ${result.error.message}`, args: call.arguments?.slice(0, 300) });
       return { type: "function_call_output", call_id: call.call_id, output: JSON.stringify(result) };
     }
 
@@ -442,7 +446,7 @@ export class AgentLoop {
       const errorMsg = !result.ok
         ? result.error.message
         : `Command exited with code ${shellExitCode}: ${String((result.data as any)?.stdout ?? "").slice(0, 200)}`;
-      failureTracker.record(call.name, call.arguments ?? "{}", errorMsg);
+      failureTracker.record(call.name, rawArgs, errorMsg);
     } else if (!this.tools.isReadOnly(call.name) && !isShellTool(call.name)) {
       failureTracker.markProgress();
     }

--- a/tests/agentLoop.test.mjs
+++ b/tests/agentLoop.test.mjs
@@ -140,6 +140,52 @@ test("failed shell verification command can rerun after a successful patch", asy
   assert.doesNotMatch(output, /repeated_failure_blocked/);
 });
 
+test("repeated failure guard blocks identical read-only failures", async () => {
+  const { loop, toolCalls } = makeLoop({
+    responses: [
+      responseWithTool("r1", functionCall("read_file_range", { path: "missing.ts" }, "c1")),
+      responseWithTool("r2", functionCall("read_file_range", { path: "missing.ts" }, "c2")),
+      responseWithText("r3", "final")
+    ],
+    isReadOnly(name) {
+      return name === "read_file_range";
+    },
+    execute() {
+      return { ok: false, error: { code: "not_found", message: "missing.ts not found" } };
+    }
+  });
+
+  const output = await loop.run("inspect missing file", true);
+
+  assert.equal(toolCalls.length, 1);
+  assert.match(output, /repeated_failure_blocked/);
+});
+
+test("repeated failure guard records malformed tool arguments", async () => {
+  const malformedCall = {
+    type: "function_call",
+    name: "read_file_range",
+    call_id: "bad-json",
+    arguments: "{"
+  };
+  const { loop, toolCalls } = makeLoop({
+    responses: [
+      responseWithTool("r1", malformedCall),
+      responseWithTool("r2", { ...malformedCall, call_id: "bad-json-again" }),
+      responseWithText("r3", "final")
+    ],
+    isReadOnly(name) {
+      return name === "read_file_range";
+    }
+  });
+
+  const output = await loop.run("inspect file", true);
+
+  assert.equal(toolCalls.length, 0);
+  assert.match(output, /json_parse_error/);
+  assert.match(output, /repeated_failure_blocked/);
+});
+
 test("multiple tool calls are rejected and corrected before execution", async () => {
   const { loop, payloads, toolCalls } = makeLoop({
     config: { conversationMode: "stateless" },


### PR DESCRIPTION
## Summary

- Apply the exact repeated-failure guard to all tool calls, including read-only inspection tools.
- Record malformed tool arguments as failures so repeating the same invalid call is blocked.
- Include runtime guard error codes in action summaries for easier diagnosis.

## Validation

- `npm test`

Part of #43.