### PR TITLE
[codex] Record verifier follow-up tasks

### DIFF
--- a/src/agent/AgentLoop.ts
+++ b/src/agent/AgentLoop.ts
@@ -267,6 +267,7 @@ export class AgentLoop {
                 pinned: false,
                 expiresAfterSteps: 4
               });
+              recordVerifierTasks(this.context, verdict);
               pendingInput = feedback;
               step++;
               continue;
@@ -508,6 +509,27 @@ function buildVerifierMemoryFacts(items: ContextItem[]): EvidenceMemoryFact[] {
       factConfidence: item.factConfidence ?? "uncertain",
       source: item.source
     }));
+}
+
+function recordVerifierTasks(
+  context: ContextManager,
+  verdict: import("./EvidenceBundle.js").VerifierVerdict
+): void {
+  const tasks = [
+    ...verdict.requiredNextActions,
+    ...verdict.unsupportedAssumptions.map((item) => item.requiredVerification)
+  ].filter((item): item is string => Boolean(item.trim()));
+
+  for (const task of [...new Set(tasks)]) {
+    context.add({
+      type: "verification_task",
+      content: task,
+      priority: 90,
+      expiresAfterSteps: 6,
+      factSource: "model_inference",
+      factConfidence: "uncertain"
+    });
+  }
 }
 
 function oneLine(value: string, max: number): string {

--- a/src/context/ContextItem.ts
+++ b/src/context/ContextItem.ts
@@ -25,6 +25,7 @@ export type ContextItem = {
     | "action_record"
     | "failure_record"
     | "verifier_feedback"
+    | "verification_task"
     | "final";
   content: string;
   tokensEstimate: number;

--- a/tests/agentLoop.test.mjs
+++ b/tests/agentLoop.test.mjs
@@ -55,7 +55,13 @@ function makeLoop({ responses, config = {}, execute, isReadOnly, contextItems = 
       ...config
     },
     {
-      upsert() {},
+      upsert(id, item) {
+        const existingIndex = storedContextItems.findIndex((entry) => entry.id === id);
+        const full = { ...item, id, tokensEstimate: item.tokensEstimate ?? 1 };
+        if (existingIndex === -1) storedContextItems.push(full);
+        else storedContextItems[existingIndex] = full;
+        return full;
+      },
       nextStep() {},
       relevant() {
         return storedContextItems;
@@ -100,7 +106,7 @@ function makeLoop({ responses, config = {}, execute, isReadOnly, contextItems = 
     },
     ""
   );
-  return { loop, payloads, toolCalls };
+  return { loop, payloads, toolCalls, contextItems: storedContextItems };
 }
 
 test("stateless plan-only reprompt is injected into the next stateless prompt", async () => {
@@ -163,7 +169,7 @@ test("multiple tool calls are rejected and corrected before execution", async ()
 });
 
 test("verifier audits zero-tool final answers and reports retry exhaustion", async () => {
-  const { loop, payloads } = makeLoop({
+  const { loop, payloads, contextItems } = makeLoop({
     config: { enableVerifier: true, verifierMaxRetries: 1 },
     responses: [
       responseWithText("r1", "src/agent/Agent.ts exports Agent"),
@@ -195,6 +201,12 @@ test("verifier audits zero-tool final answers and reports retry exhaustion", asy
   assert.match(String(verifierInput), /No tool calls recorded/);
   assert.match(output, /Retry budget exhausted/);
   assert.match(output, /read src\/agent\/Agent\.ts/);
+  assert.deepEqual(
+    contextItems
+      .filter((item) => item.type === "verification_task")
+      .map((item) => item.content),
+    ["read_file_range src/agent/Agent.ts"]
+  );
 });
 
 test("verifier receives runtime memory facts with provenance", async () => {


### PR DESCRIPTION
## Summary

- Add a `verification_task` context item type for verifier-required follow-up work.
- Record verifier `requiredNextActions` and unsupported-assumption verification steps as pending context tasks.
- Extend verifier coverage to assert required follow-up work is tracked by the runtime.

## Validation

- `npm test`

Part of #43.